### PR TITLE
DM-36955: Add an abstract directive

### DIFF
--- a/demo/index.rst
+++ b/demo/index.rst
@@ -2,7 +2,9 @@
 Demo technote
 #############
 
-A *technote* is a web-native single page document that enables rapid technical communication within and across teams.
+.. abstract::
+
+   A *technote* is a web-native single page document that enables rapid technical communication within and across teams.
 
 .. Three alphabets is a good guage for line length. We want to shoot for 2-3 alphabets.
 .. abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,6 +10,9 @@ Python API reference
 .. automodapi:: technote.config
    :include-all-objects:
 
+.. automodapi:: technote.ext
+   :include-all-objects:
+
 .. automodapi:: technote.metadata.orcid
    :include-all-objects:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "pytest-asyncio",
     "pre-commit",
     "mypy",
+    "types-docutils",
     # Documentation
     "documenteer[guide]",
     "autodoc_pydantic"

--- a/src/technote/config.py
+++ b/src/technote/config.py
@@ -490,7 +490,7 @@ class TechnoteSphinxConfig:
             project.
         """
         path = Path("technote.toml")
-        if not path.is_file:
+        if not path.is_file():
             raise ConfigError("Cannot find the technote.toml file.")
         return cls.load(path.read_text())
 

--- a/src/technote/ext/__init__.py
+++ b/src/technote/ext/__init__.py
@@ -1,0 +1,39 @@
+"""Sphinx extensions for Technote documents."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from sphinx.application import Sphinx
+
+from technote import __version__
+
+from .abstract import (
+    AbstractDirective,
+    AbstractNode,
+    depart_abstract_node_html,
+    depart_abstract_node_tex,
+    visit_abstract_node_html,
+    visit_abstract_node_tex,
+)
+
+__all__ = ["setup"]
+
+
+def setup(app: Sphinx) -> Dict[str, Any]:
+    """Set up Technote's own Sphinx extensions; these are automatically loaded
+    in all technotes by default.
+    """
+    # Abstract
+    app.add_directive("abstract", AbstractDirective)
+    app.add_node(
+        AbstractNode,
+        html=(visit_abstract_node_html, depart_abstract_node_html),
+        latex=(visit_abstract_node_tex, depart_abstract_node_tex),
+    )
+
+    return {
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/src/technote/ext/abstract.py
+++ b/src/technote/ext/abstract.py
@@ -1,0 +1,68 @@
+"""Support for abstracts in technotes."""
+
+from __future__ import annotations
+
+from typing import List
+
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+from sphinx.writers.html5 import HTML5Translator
+from sphinx.writers.latex import LaTeXTranslator
+
+__all__ = [
+    "AbstractDirective",
+    "AbstractNode",
+    "visit_abstract_node_html",
+    "depart_abstract_node_html",
+]
+
+
+class AbstractNode(nodes.General, nodes.Element):
+    """A docutils node for the abstract content section."""
+
+
+def visit_abstract_node_html(
+    self: HTML5Translator, node: nodes.Element
+) -> None:
+    """Add HTML content before the `AbstractNode`."""
+    print(type(self))
+    self.body.append('<section class="technote-abstract">')
+    self.body.append('<h2 class="technote-abstract__header">Abstract</h2>')
+
+
+def depart_abstract_node_html(
+    self: HTML5Translator, node: nodes.Element
+) -> None:
+    """Add HTML content after the `AbstractNode`."""
+    self.body.append("</section>")
+
+
+def visit_abstract_node_tex(
+    self: LaTeXTranslator, node: nodes.Element
+) -> None:
+    """Add LaTeX content before the `AbstractNode`."""
+    self.body.append(r"\begin{abstract}")
+
+
+def depart_abstract_node_tex(
+    self: LaTeXTranslator, node: nodes.Element
+) -> None:
+    """Add LaTeX content after the `AbstractNode`."""
+    self.body.append(r"\end{abstract}")
+
+
+class AbstractDirective(SphinxDirective):
+    """The ``abstract`` directive for marking up a technote's summary."""
+
+    required_arguments = 0
+    optional_arguments = 0
+    final_argument_whitespace = False
+    has_content = True
+
+    def run(self) -> List[nodes.Node]:
+        """Run the directive on content."""
+        abstract_node = AbstractNode("\n".join(self.content))
+        self.state.nested_parse(
+            self.content, self.content_offset, abstract_node
+        )
+        return [abstract_node]

--- a/src/technote/sphinxconf.py
+++ b/src/technote/sphinxconf.py
@@ -46,7 +46,7 @@ author = _t.author
 exclude_patterns = ["_build", "README.rst", "README.md", "Makefile"]
 html_theme = "technote"
 
-extensions: List[str] = []
+extensions: List[str] = ["technote.ext"]
 _t.append_extensions(extensions)
 
 # Nitpicky settings and ignored errors


### PR DESCRIPTION
This abstract marks up the technote's abstract, making it easier to style in the outputs (HTML and LaTeX writers supported), and also detect for metadata.