### PR TITLE
DM-40684: Update to Pydantic 2 and other infrastructure updates

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,0 @@
-[flake8]
-max-line-length = 79
-# E203: whitespace before :, flake8 disagrees with PEP-8
-# W503: line break after binary operator, flake8 disagrees with PEP-8
-ignore = E203, W503
-exclude =
-    docs/conf.py

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
@@ -37,9 +37,7 @@ jobs:
     strategy:
       matrix:
         python:
-          - '3.8'
-          - '3.9'
-          - '3.10'
+          - '3.11'
 
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +72,7 @@ jobs:
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           tox-envs: 'demo,docs'
           # tox-envs: "docs,docs-linkcheck"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 name: Python CI
 
 'on':
+  merge_group: {}
+  pull_request: {}
   push:
     branches-ignore:
       # These should always correspond to pull requests, so ignore them for
@@ -8,12 +10,12 @@ name: Python CI
       # trigger, avoiding running the workflow twice.  This is a minor
       # optimization so there's no need to ensure this is comprehensive.
       - 'dependabot/**'
+      - 'gh-readonly-queue/**'
       - 'renovate/**'
       - 'tickets/**'
       - 'u/**'
-    tags:
-      - '*'
-  pull_request: {}
+  release:
+    types: [published]
 
 jobs:
   lint:
@@ -91,28 +93,42 @@ jobs:
           github.event_name != 'pull_request' || startsWith(github.head_ref, 'tickets/')
 
 
-  pypi:
+  test-packaging:
+    name: Test packaging
     runs-on: ubuntu-latest
-    needs: [lint, test, docs]
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
-      - uses: actions/setup-node@v3
+      - name: Build and publish
+        uses: lsst-sqre/build-and-publish-to-pypi@v2
         with:
-          cache: 'npm'
-          node-version-file: '.nvmrc'
+          python-version: '3.11'
+          upload: false
 
-      - name: npm install and build
-        run: |
-          npm install
-          npm run build
+  pypi:
+    # This job requires set up:
+    # 1. Set up a trusted publisher for PyPI
+    # 2. Set up a "pypi" environment in the repository
+    # See https://github.com/lsst-sqre/build-and-publish-to-pypi
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    needs: [lint, test, docs, test-packaging]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/technote
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history for setuptools_scm
 
       - name: Build and publish
-        uses: lsst-sqre/build-and-publish-to-pypi@v1
+        uses: lsst-sqre/build-and-publish-to-pypi@v2
         with:
-          pypi-token: ${{ secrets.PYPI_SQRE_ADMIN }}
-          python-version: '3.10'
-          upload: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+          python-version: '3.11'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -40,7 +40,7 @@ jobs:
           - '3.10'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v3
         with:
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
@@ -96,7 +96,7 @@ jobs:
     needs: [lint, test, docs]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history for setuptools_scm
 

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -1,0 +1,33 @@
+name: Dependency Update
+
+'on':
+  schedule:
+    - cron: '0 12 * * 1'
+  workflow_dispatch: {}
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run neophile
+        uses: lsst-sqre/run-neophile@v1
+        with:
+          python-version: '3.11'
+          mode: pr
+          types: pre-commit
+          app-id: ${{ secrets.NEOPHILE_APP_ID }}
+          app-secret: ${{ secrets.NEOPHILE_PRIVATE_KEY }}
+
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+          notification_title: 'Periodic dependency update for {repo} failed'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -52,7 +52,8 @@ jobs:
           tox-envs: 'demo,docs,docs-linkcheck'
           use-cache: false
 
-  pypi:
+  test-packaging:
+    name: Test packaging
     runs-on: ubuntu-latest
 
     steps:
@@ -60,19 +61,8 @@ jobs:
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
-      - uses: actions/setup-node@v3
-        with:
-          cache: 'npm'
-          node-version-file: '.nvmrc'
-
-      - name: npm install and build
-        run: |
-          npm install
-          npm run build
-
       - name: Build and publish
-        uses: lsst-sqre/build-and-publish-to-pypi@v1
+        uses: lsst-sqre/build-and-publish-to-pypi@v2
         with:
-          pypi-token: ''
-          python-version: '3.10'
+          python-version: '3.11'
           upload: false

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -15,9 +15,7 @@ jobs:
     strategy:
       matrix:
         python:
-          - '3.8'
-          - '3.9'
-          - '3.10'
+          - '3.11'
 
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +46,7 @@ jobs:
       - name: Build docs in tox
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           tox-envs: 'demo,docs,docs-linkcheck'
           use-cache: false
 

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -20,7 +20,7 @@ jobs:
           - '3.10'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v3
         with:
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build docs in tox
         uses: lsst-sqre/run-tox@v1
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history for setuptools_scm
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,11 @@ repos:
     hooks:
       - id: prettier
 
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.278
     hooks:
-      - id: isort
-        additional_dependencies: [toml]
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black
     rev: 23.7.0
@@ -27,15 +27,4 @@ repos:
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==23.7.0]
-        args: [-l, '79', -t, py38]
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
-    hooks:
-      - id: flake8
-
-  - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.3.0
-    hooks:
-      - id: pydocstyle
-        additional_dependencies: [toml]
+        args: [-l, '79', -t, py311]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,41 +1,41 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: check-yaml
       - id: check-toml
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 'v2.7.1'
+    rev: 'v3.0.3'
     hooks:
       - id: prettier
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies: [toml]
 
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.7.0
     hooks:
       - id: black
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.1
+    rev: 1.16.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==22.6.0]
+        additional_dependencies: [black==23.7.0]
         args: [-l, '79', -t, py38]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.2
+    rev: 6.1.0
     hooks:
       - id: flake8
 
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.1.1
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
         additional_dependencies: [toml]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-<!-- Format for headings: 1.2.3 (YYYY-MM-DD) -->
+<!-- scriv-insert-here -->
 
 ## 0.2.0 (2022-12-05)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: init
 init:
-	pip install --upgrade pip tox pre-commit
+	pip install --upgrade pip tox pre-commit scriv
 	pip install --upgrade -e ".[dev]"
 	pre-commit install
 	rm -rf .tox

--- a/changelog.d/20230911_165815_jsick_DM_40684.md
+++ b/changelog.d/20230911_165815_jsick_DM_40684.md
@@ -1,0 +1,8 @@
+### Backwards-incompatible changes
+
+- Require Pydantic 2 and later
+- Require Python 3.11 and later
+
+### Other changes
+
+- Adopt Ruff for linting

--- a/changelog.d/_template.md.jinja
+++ b/changelog.d/_template.md.jinja
@@ -1,0 +1,7 @@
+<!-- Delete the sections that don't apply -->
+{%- for cat in config.categories %}
+
+### {{ cat }}
+
+-
+{%- endfor %}

--- a/demo/conf.py
+++ b/demo/conf.py
@@ -1,4 +1,4 @@
-from technote.sphinxconf import *  # noqa: F401 F403
+from technote.sphinxconf import *  # noqa: F403
 
 html_static_path = ["_static"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dev = [
     "lxml",
     "cssselect",
     # Documentation
-    "documenteer[guide] @ git+https://github.com/lsst-sqre/documenteer@tickets/DM-40684",
+    "documenteer[guide] @ git+https://github.com/lsst-sqre/documenteer@main",
     "autodoc_pydantic",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "Sphinx",
     "sphinx-basic-ng>=1.0.0b1",
     "base32-lib",
-    "pydantic[email]<2",
+    "pydantic[email]>=2.0.0",
     "beautifulsoup4",
 ]
 dynamic = ["version"]
@@ -40,7 +40,7 @@ dev = [
     "lxml",
     "cssselect",
     # Documentation
-    "documenteer[guide]",
+    "documenteer[guide] @ git+https://github.com/lsst-sqre/documenteer@tickets/DM-40684",
     "autodoc_pydantic",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,21 +11,17 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: POSIX",
     "Typing :: Typed",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 dependencies = [
     "Sphinx",
     "sphinx-basic-ng>=1.0.0b1",
     "base32-lib",
-    "tomli; python_version < \"3.11\"",
     "pydantic[email]<2",
     "beautifulsoup4",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,3 +147,16 @@ exclude = [
     "tests/roots", # ignore conf.py files from test cases
 ]
 # plugins =
+
+[tool.scriv]
+categories = [
+    "Backwards-incompatible changes",
+    "New features",
+    "Bug fixes",
+    "Other changes",
+]
+entry_title_template = "{{ version }} ({{ date.strftime('%Y-%m-%d') }})"
+format = "md"
+md_header_level = "2"
+new_fragment_template = "file:changelog.d/_template.md.jinja"
+skip_fragments = "_template.md.jinja"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: POSIX",
@@ -90,7 +91,7 @@ exclude_lines = [
 
 [tool.black]
 line-length = 79
-target-version = ["py38"]
+target-version = ["py311"]
 exclude = '''
 /(
     \.eggs
@@ -105,31 +106,6 @@ exclude = '''
 '''
 # Use single-quoted strings so TOML treats the string like a Python r-string
 #  Multi-line strings are implicitly treated by black as regular expressions
-
-[tool.pydocstyle]
-# Reference: http://www.pydocstyle.org/en/stable/error_codes.html
-convention = "numpy"
-add_select = [
-    "D212", # Multi-line docstring summary should start at the first line
-]
-add-ignore = [
-    "D105", # Missing docstring in magic method
-    "D102", # Missing docstring in public method (needed for docstring inheritance)
-    "D100", # Missing docstring in public module
-    # Below are required to allow multi-line summaries.
-    "D200", # One-line docstring should fit on one line with quotes
-    "D205", # 1 blank line required between summary line and description
-    "D400", # First line should end with a period
-    # Properties shouldn't be written in imperative mode. This will be fixed
-    # post 6.1.1, see https://github.com/PyCQA/pydocstyle/pull/546
-    "D401",
-]
-
-[tool.isort]
-profile = "black"
-line_length = 79
-known_first_party = ["technote", "tests"]
-skip = ["docs/conf.py"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
@@ -160,3 +136,98 @@ format = "md"
 md_header_level = "2"
 new_fragment_template = "file:changelog.d/_template.md.jinja"
 skip_fragments = "_template.md.jinja"
+
+# The rule used with Ruff configuration is to disable every lint that has
+# legitimate exceptions that are not dodgy code, rather than cluttering code
+# with noqa markers. This is therefore a reiatively relaxed configuration that
+# errs on the side of disabling legitimate lints.
+#
+# Reference for settings: https://beta.ruff.rs/docs/settings/
+# Reference for rules: https://beta.ruff.rs/docs/rules/
+[tool.ruff]
+exclude = [
+    "docs/**",
+    "demo/**",
+    "tests/roots/**",
+]
+line-length = 79
+ignore = [
+    "A001",    # To permit using license as a model attribute
+    "A003",    # To permit using license as a model attribute
+    "ANN101",  # self should not have a type annotation
+    "ANN102",  # cls should not have a type annotation
+    "ANN401",  # sometimes Any is the right type
+    "ARG001",  # unused function arguments are often legitimate
+    "ARG002",  # unused method arguments are often legitimate
+    "ARG005",  # unused lambda arguments are often legitimate
+    "BLE001",  # we want to catch and report Exception in background tasks
+    "C414",    # nested sorted is how you sort by multiple keys with reverse
+    "COM812",  # omitting trailing commas allows black autoreformatting
+    "D102",    # sometimes we use docstring inheritence
+    "D104",    # don't see the point of documenting every package
+    "D105",    # our style doesn't require docstrings for magic methods
+    "D106",    # Pydantic uses a nested Config class that doesn't warrant docs
+    "D205",    # Allow multiple lines for summary sentence
+    "EM101",   # justification (duplicate string in traceback) is silly
+    "EM102",   # justification (duplicate string in traceback) is silly
+    "FBT003",  # positional booleans are normal for Pydantic field defaults
+    "FIX001",  # fixmes are fine
+    "G004",    # forbidding logging f-strings is appealing, but not our style
+    "RET505",  # disagree that omitting else always makes code more readable
+    "PLR0913", # factory pattern uses constructors with many arguments
+    "PLR2004", # too aggressive about magic values
+    "S105",    # good idea but too many false positives on non-passwords
+    "S106",    # good idea but too many false positives on non-passwords
+    "SIM102",  # sometimes the formatting of nested if statements is clearer
+    "SIM117",  # sometimes nested with contexts are clearer
+    "SLOT000", # str+Enum sublcasses don't need slots
+    "TCH001",  # we decided to not maintain separate TYPE_CHECKING blocks
+    "TCH002",  # we decided to not maintain separate TYPE_CHECKING blocks
+    "TCH003",  # we decided to not maintain separate TYPE_CHECKING blocks
+    "TID252",  # if we're going to use relative imports, use them always
+    "TD001",   # don't care about formatting TODOs
+    "TD002",   # don't care about formatting TODOs
+    "TD003",   # don't care about formatting TODOs
+    "TD004",   # don't care about formatting TODOs
+    "TRY003",  # good general advice but lint is way too aggressive
+]
+select = ["ALL"]
+target-version = "py311"
+
+[tool.ruff.per-file-ignores]
+"tests/**" = [
+    "D103",    # tests don't need docstrings
+    "PLR0915", # tests are allowed to be long, sometimes that's convenient
+    "PT012",   # way too aggressive about limiting pytest.raises blocks
+    "S101",    # tests should use assert
+    "SLF001",  # tests are allowed to access private members
+]
+
+[tool.ruff.isort]
+known-first-party = ["technote", "tests"]
+split-on-trailing-comma = false
+
+# These are too useful as attributes or methods to allow the conflict with the
+# built-in to rule out their use.
+[tool.ruff.flake8-builtins]
+builtins-ignorelist = [
+    "all",
+    "any",
+    "help",
+    "id",
+    "list",
+    "type",
+]
+
+[tool.ruff.flake8-pytest-style]
+fixture-parentheses = false
+mark-parentheses = false
+
+[tool.ruff.pep8-naming]
+classmethod-decorators = [
+    "pydantic.root_validator",
+    "pydantic.validator",
+]
+
+[tool.ruff.pydocstyle]
+convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "sphinx-basic-ng>=1.0.0b1",
     "base32-lib",
     "tomli; python_version < \"3.11\"",
-    "pydantic[email]",
+    "pydantic[email]<2",
     "beautifulsoup4",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,7 @@ warn_unused_ignores = true
 exclude = [
     "tests/roots", # ignore conf.py files from test cases
 ]
-# plugins =
+plugins = ["pydantic.mypy"]
 
 [tool.scriv]
 categories = [

--- a/src/technote/__init__.py
+++ b/src/technote/__init__.py
@@ -4,7 +4,7 @@ __all__ = ["__version__", "setup"]
 
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 from sphinx.application import Sphinx
 
@@ -18,7 +18,7 @@ except PackageNotFoundError:
     __version__ = "0.0.0"
 
 
-def setup(app: Sphinx) -> Dict[str, Any]:
+def setup(app: Sphinx) -> dict[str, Any]:
     """Sphinx entrypoint for technote.
 
     Parameters

--- a/src/technote/config.py
+++ b/src/technote/config.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import os
 import re
-import sys
+import tomllib
 from collections.abc import MutableMapping
 from dataclasses import dataclass
 from datetime import date
@@ -25,11 +25,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
-
-if sys.version_info < (3, 11):
-    import tomli as tomllib
-else:
-    import tomllib
 
 from pydantic import (
     BaseModel,

--- a/src/technote/ext/__init__.py
+++ b/src/technote/ext/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 
 from sphinx.application import Sphinx
 
@@ -22,7 +22,7 @@ from .toc import process_html_page_context_for_toc
 __all__ = ["setup"]
 
 
-def setup(app: Sphinx) -> Dict[str, Any]:
+def setup(app: Sphinx) -> dict[str, Any]:
     """Set up Technote's own Sphinx extensions; these are automatically loaded
     in all technotes by default.
     """

--- a/src/technote/ext/abstract.py
+++ b/src/technote/ext/abstract.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import List
-
 from docutils import nodes
 from sphinx.util.docutils import SphinxDirective
 from sphinx.writers.html5 import HTML5Translator
@@ -58,7 +56,7 @@ class AbstractDirective(SphinxDirective):
     final_argument_whitespace = False
     has_content = True
 
-    def run(self) -> List[nodes.Node]:
+    def run(self) -> list[nodes.Node]:
         """Run the directive on content."""
         abstract_node = AbstractNode("\n".join(self.content))
         self.state.nested_parse(

--- a/src/technote/ext/metadata.py
+++ b/src/technote/ext/metadata.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 from docutils import nodes
 from sphinx.application import Sphinx
@@ -21,8 +21,8 @@ __all__ = [
 def get_title(
     *,
     app: Sphinx,
-    context: Dict[str, Any],
-    doctree: Optional[nodes.document],
+    context: dict[str, Any],
+    doctree: nodes.document | None,
     config: Config,
 ) -> None:
     """Get the H1 title to use as the technote title."""
@@ -38,8 +38,8 @@ def get_title(
 def get_abstract(
     *,
     app: Sphinx,
-    context: Dict[str, Any],
-    doctree: Optional[nodes.document],
+    context: dict[str, Any],
+    doctree: nodes.document | None,
     config: Config,
 ) -> None:
     """Get the abstract as plain text from the abstract directive."""
@@ -52,7 +52,7 @@ def get_abstract(
             break
 
 
-def set_html_title(*, context: Dict[str, Any]) -> None:
+def set_html_title(*, context: dict[str, Any]) -> None:
     """Set the ``html_title`` and ``project`` metadata based on the
     title metadata, resolved from either technote.toml or the content's
     top-level heading.
@@ -64,8 +64,8 @@ def process_html_page_context_for_metadata(
     app: Sphinx,
     pagename: str,
     templatename: str,
-    context: Dict[str, Any],
-    doctree: Optional[nodes.document],
+    context: dict[str, Any],
+    doctree: nodes.document | None,
 ) -> None:
     """Process the HTML page to prepare the context for the HTML templates.
 

--- a/src/technote/ext/toc.py
+++ b/src/technote/ext/toc.py
@@ -6,11 +6,12 @@ context variable.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from bs4 import BeautifulSoup
 from docutils import nodes
 from sphinx.application import Sphinx
+from sphinx.util import logging
 
 from .abstract import AbstractNode
 
@@ -21,16 +22,18 @@ def process_html_page_context_for_toc(
     app: Sphinx,
     pagename: str,
     templatename: str,
-    context: Dict[str, Any],
-    doctree: Optional[nodes.document],
+    context: dict[str, Any],
+    doctree: nodes.document | None,
 ) -> None:
     """Process the HTML page context to add a new ``technote-toc`` context
     variable.
 
     This function is hooked into the Sphinx ``html-page-context`` event.
     """
-    print(f"page: {pagename}")
-    print(f"template: {templatename}")
+    logger = logging.getLogger(__name__)
+
+    logger.debug(f"In toc, page: {pagename}", location=pagename)
+    logger.debug(f"In toc, template: {templatename}", location=pagename)
     try:
         default_toc_html = context["toc"]
     except KeyError:
@@ -38,7 +41,7 @@ def process_html_page_context_for_toc(
         context["technote_toc"] = ""
         return
 
-    prepend_sections: List[SyntheticTocSection] = []
+    prepend_sections: list[SyntheticTocSection] = []
 
     # Find an abstract node, which isn't collected by Sphinx for the local toc
     if doctree:
@@ -55,7 +58,7 @@ def process_html_page_context_for_toc(
 
 def transform_toc_html(
     sphinx_toc: str,
-    prepend_sections: Optional[List[SyntheticTocSection]] = None,
+    prepend_sections: list[SyntheticTocSection] | None = None,
 ) -> str:
     """Transform the Sphinx toc HTML for technotes.
 

--- a/src/technote/metadata/orcid.py
+++ b/src/technote/metadata/orcid.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Generator
+from collections.abc import Generator
+from typing import Any
 
 from pydantic import BaseConfig, HttpUrl
 from pydantic.errors import UrlError
@@ -44,7 +45,7 @@ class Orcid(HttpUrl):
     This validator implments the ISO 7064 11,2 checksum algorithm.
     """
 
-    allowed_schemes = {"https"}
+    allowed_schemes = {"https"}  # noqa: RUF012
 
     @classmethod
     def __get_validators__(cls) -> Generator[AnyCallable, None, None]:
@@ -59,11 +60,11 @@ class Orcid(HttpUrl):
 
         m = ORCID_PATTERN.search(value)
         if not m:
-            raise OrcidError()
+            raise OrcidError
 
         identifier = m["identifier"]
         if not cls.verify_checksum(identifier):
-            raise OrcidError()
+            raise OrcidError
 
         return HttpUrl.validate(
             f"https://orcid.org/{identifier}", field, config
@@ -76,11 +77,10 @@ class Orcid(HttpUrl):
         """
         total: int = 0
         for digit in identifier:
-            if digit == "X":
-                digit = "10"
-            if not digit.isdigit():
+            numeric_digit = "10" if digit == "X" else digit
+            if not numeric_digit.isdigit():
                 continue
-            total = (total + int(digit)) * 2
+            total = (total + int(numeric_digit)) * 2
         remainder = total % 11
         result = (12 - remainder) % 11
         return result == 10

--- a/src/technote/metadata/ror.py
+++ b/src/technote/metadata/ror.py
@@ -3,16 +3,11 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Generator
-from typing import Any
 
 import base32_lib as base32
-from pydantic import BaseConfig, HttpUrl
-from pydantic.errors import UrlError
-from pydantic.fields import ModelField
-from pydantic.typing import AnyCallable
+from pydantic import HttpUrl
 
-__all__ = ["Ror", "RorError"]
+__all__ = ["validate_ror_url"]
 
 ROR_PATTERN = re.compile(
     r"https://ror.org"
@@ -21,37 +16,19 @@ ROR_PATTERN = re.compile(
 )
 
 
-class RorError(UrlError):
-    """An error validating a ROR identifier, raised by Pydantic."""
+def validate_ror_url(value: HttpUrl) -> None:
+    """Check a ROR URL for validity.
 
-    code = "ror"
-    msg_template = "invalid ROR"
-
-
-class Ror(HttpUrl):
-    """A ROR (Research Organization Registry) type for Pydantic validation."""
-
-    allowed_schemes = {"https"}  # noqa: RUF012
-
-    @classmethod
-    def __get_validators__(cls) -> Generator[AnyCallable, None, None]:
-        yield cls.validate
-
-    @classmethod
-    def validate(
-        cls, value: Any, field: ModelField, config: BaseConfig
-    ) -> Ror:
-        if value.__class__ == cls:
-            return value
-
-        m = ROR_PATTERN.search(value)
-        if not m:
-            raise RorError
-
-        identifier = m["identifier"]
-        try:
-            base32.decode(identifier, checksum=True)
-        except ValueError as e:
-            raise RorError from e
-
-        return HttpUrl.validate(value, field, config)
+    Raises
+    ------
+    ValueError
+        Raised if the URL is not a valid ROR URL.
+    """
+    m = ROR_PATTERN.search(str(value))
+    if not m:
+        raise ValueError(f"Expected ROR URL, received: {value}")
+    identifier = m["identifier"]
+    try:
+        base32.decode(identifier, checksum=True)
+    except ValueError as e:
+        raise ValueError("ROR identifier checksum failed") from e

--- a/src/technote/metadata/ror.py
+++ b/src/technote/metadata/ror.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Generator
+from collections.abc import Generator
+from typing import Any
 
 import base32_lib as base32
 from pydantic import BaseConfig, HttpUrl
@@ -30,7 +31,7 @@ class RorError(UrlError):
 class Ror(HttpUrl):
     """A ROR (Research Organization Registry) type for Pydantic validation."""
 
-    allowed_schemes = {"https"}
+    allowed_schemes = {"https"}  # noqa: RUF012
 
     @classmethod
     def __get_validators__(cls) -> Generator[AnyCallable, None, None]:
@@ -45,12 +46,12 @@ class Ror(HttpUrl):
 
         m = ROR_PATTERN.search(value)
         if not m:
-            raise RorError()
+            raise RorError
 
         identifier = m["identifier"]
         try:
             base32.decode(identifier, checksum=True)
-        except ValueError:
-            raise RorError()
+        except ValueError as e:
+            raise RorError from e
 
         return HttpUrl.validate(value, field, config)

--- a/src/technote/metadata/spdx.py
+++ b/src/technote/metadata/spdx.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -62,7 +63,8 @@ class SpdxFile(BaseModel):
             https://github.com/spdx/license-list-data/blob/master/json/licenses.json.
         """
         p = Path(__file__).parent / "licenses.json"
-        return cls.parse_file(p, content_type="application/json")
+        data = json.loads(p.read_text())
+        return cls.model_validate(data)
 
 
 @dataclass

--- a/src/technote/metadata/spdx.py
+++ b/src/technote/metadata/spdx.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List
 
 from pydantic import BaseModel, Field, HttpUrl
 
@@ -22,7 +21,7 @@ class SpdxLicense(BaseModel):
         ..., alias="licenseId", description="SPDX license identifier."
     )
 
-    see_also: List[HttpUrl] = Field(
+    see_also: list[HttpUrl] = Field(
         default_factory=list,
         alias="seeAlso",
         description="URLs to documentation about this license.",
@@ -41,13 +40,13 @@ class SpdxLicense(BaseModel):
 class SpdxFile(BaseModel):
     """Representation of a SPDX license database file as a Pydantic model."""
 
-    license_listVersion: str = Field(
+    license_list_version: str = Field(
         ...,
         alias="licenseListVersion",
         description="Version string of this license file.",
     )
 
-    licenses: List[SpdxLicense]
+    licenses: list[SpdxLicense]
     """The licenses."""
 
     @classmethod
@@ -70,7 +69,7 @@ class SpdxFile(BaseModel):
 class Licenses:
     """License database, with access by license ID."""
 
-    licenses: Dict[str, SpdxLicense]
+    licenses: dict[str, SpdxLicense]
     """Internal license dictionary, keyed by the SPDX ID."""
 
     @classmethod
@@ -83,7 +82,7 @@ class Licenses:
             The license database instance.
         """
         spdx_file = SpdxFile.load_internal()
-        licenses: Dict[str, SpdxLicense] = {
+        licenses: dict[str, SpdxLicense] = {
             license.license_id: license for license in spdx_file.licenses
         }
         return cls(licenses=licenses)

--- a/src/technote/sphinxconf.py
+++ b/src/technote/sphinxconf.py
@@ -7,7 +7,7 @@ To use this configuration in a Technote project, write a conf.py containing::
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any
 
 from .config import TechnoteSphinxConfig
 
@@ -48,23 +48,23 @@ author = _t.author or ""
 exclude_patterns = ["_build", "README.rst", "README.md", "Makefile"]
 html_theme = "technote"
 
-extensions: List[str] = ["technote.ext"]
+extensions: list[str] = ["technote.ext"]
 _t.append_extensions(extensions)
 
 # Nitpicky settings and ignored errors
 nitpicky = _t.nitpicky
 
-nitpick_ignore: List[Tuple[str, str]] = []
+nitpick_ignore: list[tuple[str, str]] = []
 _t.append_nitpick_ignore(nitpick_ignore)
 
-nitpick_ignore_regex: List[Tuple[str, str]] = []
+nitpick_ignore_regex: list[tuple[str, str]] = []
 _t.append_nitpick_ignore_regex(nitpick_ignore_regex)
 
 # ============================================================================
 # INTERSPHINX Intersphinx settings
 # ============================================================================
 
-intersphinx_mapping: Dict[str, Tuple[str, Union[str, None]]] = {}
+intersphinx_mapping: dict[str, tuple[str, str | None]] = {}
 _t.extend_intersphinx_mapping(intersphinx_mapping)
 
 intersphinx_timeout = 10.0  # seconds
@@ -78,14 +78,14 @@ intersphinx_cache_limit = 5  # days
 
 linkcheck_retries = 2
 linkcheck_timeout = 15
-linkcheck_ignore: List[str] = []
+linkcheck_ignore: list[str] = []
 _t.append_linkcheck_ignore(linkcheck_ignore)
 
 # ============================================================================
 # HTML HTML builder settings
 # ============================================================================
 
-html_context: Dict[str, Any] = {"technote": _t.jinja_context}
+html_context: dict[str, Any] = {"technote": _t.jinja_context}
 
 if _t.toml.technote.canonical_url:
     html_baseurl = str(_t.toml.technote.canonical_url)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 """Pytest configuration and fixtures."""
 
-from typing import List
 
 import pytest
 from sphinx.testing.path import path
@@ -8,7 +7,7 @@ from sphinx.testing.path import path
 pytest_plugins = ("sphinx.testing.fixtures",)
 
 # Exclude 'roots' dirs for pytest test collector
-collect_ignore: List[str] = ["roots"]
+collect_ignore: list[str] = ["roots"]
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/tests/metadata/orcid_test.py
+++ b/tests/metadata/orcid_test.py
@@ -9,7 +9,7 @@ from technote.metadata.orcid import Orcid
 
 
 @pytest.mark.parametrize(
-    "identifier,sample",
+    ("identifier", "sample"),
     [
         ("0000-0002-1825-0097", "0000-0002-1825-0097"),
         ("0000-0001-5109-3700", "hello 0000-0001-5109-3700 world"),

--- a/tests/metadata/orcid_test.py
+++ b/tests/metadata/orcid_test.py
@@ -3,42 +3,57 @@
 from __future__ import annotations
 
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, HttpUrl, ValidationError, field_validator
 
-from technote.metadata.orcid import Orcid
+from technote.metadata.orcid import validate_orcid_url, verify_checksum
+
+
+class Model(BaseModel):
+    """A model with an ORCiD type."""
+
+    orcid: HttpUrl
+
+    @field_validator("orcid", mode="after")
+    @classmethod
+    def validate_ror(cls, value: HttpUrl) -> HttpUrl:
+        validate_orcid_url(value)
+        return value
+
+    @field_validator("orcid", mode="before")
+    @classmethod
+    def format_orcid_url(cls, value: str) -> str:
+        if value.startswith(("http://oricid", "https://orcid")):
+            return value
+        if verify_checksum(value):
+            return f"https://orcid.org/{value}"
+        raise ValueError(f"Not an ORCiD identifier checksum ({value})")
 
 
 @pytest.mark.parametrize(
-    ("identifier", "sample"),
+    "sample",
     [
-        ("0000-0002-1825-0097", "0000-0002-1825-0097"),
-        ("0000-0001-5109-3700", "hello 0000-0001-5109-3700 world"),
-        ("0000-0002-1694-233X", "0000-0002-1694-233X"),
-        ("0000-0002-1825-0097", "https://orcid.org/0000-0002-1825-0097"),
-        ("0000-0001-5109-3700", "http://0000-0001-5109-3700"),
-        ("0000-0002-1694-233X", "https://0000-0002-1694-233X"),
+        "https://orcid.org/0000-0002-1825-0097",
+        "https://orcid.org/0000-0001-5109-3700",
+        "https://orcid.org/0000-0002-1694-233X",
+        "0000-0002-1825-0097",
+        "0000-0001-5109-3700",
+        "0000-0002-1694-233X",
     ],
 )
-def test_orcid(identifier: str, sample: str) -> None:
+def test_orcid(sample: str) -> None:
     """Test that a model with an Orcid field can validate."""
-
-    class Model(BaseModel):
-        orcid: Orcid
-
     m = Model(orcid=sample)
 
-    assert m.orcid == f"https://orcid.org/{identifier}"
-    assert m.orcid.path == f"/{identifier}"
     assert m.orcid.host == "orcid.org"
     assert m.orcid.scheme == "https"
+
+    assert m.orcid.path
+    identifier = m.orcid.path[1:]
+    assert verify_checksum(identifier)
 
 
 @pytest.mark.parametrize("sample", ["0000-0002-1825-0099", "0001-5109-3700"])
 def test_orcid_fail(sample: str) -> None:
     """Test mal-formed ORCiD (wrong checksum or wrong pattern)."""
-
-    class Model(BaseModel):
-        orcid: Orcid
-
     with pytest.raises(ValidationError):
         Model(orcid=sample)

--- a/tests/metadata/spdx_test.py
+++ b/tests/metadata/spdx_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pydantic import HttpUrl
+
 from technote.metadata.spdx import Licenses, SpdxFile, SpdxLicense
 
 
@@ -20,5 +22,5 @@ def test_cc_by() -> None:
     assert isinstance(license, SpdxLicense)
     assert license.name == "Creative Commons Attribution 4.0 International"
     assert license.see_also[0] == (
-        "https://creativecommons.org/licenses/by/4.0/legalcode"
+        HttpUrl("https://creativecommons.org/licenses/by/4.0/legalcode")
     )

--- a/tests/roots/test-abstract-basic/conf.py
+++ b/tests/roots/test-abstract-basic/conf.py
@@ -1,1 +1,1 @@
-from technote.sphinxconf import *  # noqa: F401 F403
+from technote.sphinxconf import *  # noqa: F403

--- a/tests/roots/test-toc-basic/conf.py
+++ b/tests/roots/test-toc-basic/conf.py
@@ -1,1 +1,1 @@
-from technote.sphinxconf import *  # noqa: F401 F403
+from technote.sphinxconf import *  # noqa: F403


### PR DESCRIPTION
- Update models to use Pydantic 2 (and require Pydantic 2)
- Adopt Ruff for linting
- Adopt Scriv for change logs
- Update GitHub Actions, including using PyPI's trusted publishers program and neophile for dependency updates.