### PR TITLE
DM-40737: Handle technotes with no sections

### DIFF
--- a/changelog.d/20230913_150726_jsick_DM_40737.md
+++ b/changelog.d/20230913_150726_jsick_DM_40737.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- The `technote.ext.toc` extension now correctly handles the case where a technote has no sections.

--- a/src/technote/ext/toc.py
+++ b/src/technote/ext/toc.py
@@ -68,6 +68,14 @@ def transform_toc_html(
     soup = BeautifulSoup(sphinx_toc, "html.parser")
     root_list = soup.select_one("li > ul")
 
+    # If there aren't any sections, there won't be a ul list in the sphinx_toc
+    # extracted by process_html_page_context_for_toc. Therefore create an
+    # empty ul.
+    if root_list is None:
+        root_list = BeautifulSoup("<ul></ul>", "html.parser").ul
+
+    # Add toc entries that aren't part of the Sphinx toc collector (such as
+    # the abstract)
     if prepend_sections:
         # reverse order to so we can insert at index 0
         for section in prepend_sections[::-1]:

--- a/tests/ext/toc_test.py
+++ b/tests/ext/toc_test.py
@@ -33,3 +33,24 @@ def test_toc_html(app: Sphinx, status: IO, warning: IO) -> None:
     first_section_li = toc_ul.cssselect("li")[1]
     assert first_section_li.text_content() == "Section one"
     assert first_section_li.cssselect("a")[0].get("href") == "#section-one"
+
+
+@pytest.mark.sphinx("html", testroot="toc-no-sections")
+def test_toc_no_sections_html(app: Sphinx, status: IO, warning: IO) -> None:
+    """Test against the ``test-toc-no-sections`` test root.
+
+    This test ensures that the technote_toc is rendered into HTML properly
+    when there are no sections.
+    """
+    app.verbosity = 2
+    logging.setup(app, status, warning)
+    app.builder.build_all()
+
+    html_source = Path(app.outdir).joinpath("index.html").read_text()
+    doc = lxml.html.document_fromstring(html_source)
+
+    toc_ul = doc.cssselect(".technote-toc-container > ul")[0]
+
+    abstract_li = toc_ul.cssselect("li")[0]
+    assert abstract_li.text_content() == "Abstract"
+    assert abstract_li.cssselect("a")[0].get("href") == "#abstract"

--- a/tests/roots/test-toc-no-sections/conf.py
+++ b/tests/roots/test-toc-no-sections/conf.py
@@ -1,0 +1,1 @@
+from technote.sphinxconf import *  # noqa: F403

--- a/tests/roots/test-toc-no-sections/index.rst
+++ b/tests/roots/test-toc-no-sections/index.rst
@@ -1,0 +1,12 @@
+###############
+TOC No Sections
+###############
+
+This document doesn't have any subsections.
+We're testing that the TOC can cope with this.
+
+.. abstract::
+
+   First paragraph of abstract.
+
+   Second paragraph of abstract.

--- a/tests/roots/test-toc-no-sections/technote.toml
+++ b/tests/roots/test-toc-no-sections/technote.toml
@@ -1,0 +1,11 @@
+[technote]
+id = "TEST-000"
+series_id = "TEST"
+title = "Abstract Basic"
+
+[[technote.authors]]
+name = { given_names = "Jonathan", family_names = "Sick" }
+orcid = "https://orcid.org/0000-0003-3001-676X"
+affiliations = [
+    { name = "Rubin Observatory", ror = "https://ror.org/048g3cy84" }
+]


### PR DESCRIPTION
When there are not sections in a technote, the original Sphinx toc won't have a `<ul>` list below the level of the main title and therefore will be empty since we extract that list of sections. The solution is to create an empty `<ul></ul>` with beautifulsoup for us to add the abstract, if necessary.