### PR TITLE
DM-40738: Add pygments styling and basic light/dark mode support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,4 @@ clean:
 	rm -rf .tox
 	rm -rf docs/_build
 	rm -rf docs/api
+	rm -f demo/_build

--- a/changelog.d/20230918_104754_jsick_DM_40738.md
+++ b/changelog.d/20230918_104754_jsick_DM_40738.md
@@ -1,0 +1,5 @@
+### New features
+
+- Light and dark colour themes are now set via a `html[data-theme='light']` or `dark` data theme attribute. JavaScript sets this element based on the user preference of 'light', 'dark', or 'auto' (using media queries for system settings). New CSS classes `technote-themed-light` and `technote-themed-dark` now determine what elements appear, or not, in certain themed contexts. This mechanism is highly inspired by pydata-sphinx-theme.
+- Pygments highlighting CSS is now applied to all code samples, with light and dark themes using the mechanism described above. The default pygments styling comes from the `accessible-pygments` package. The mechanism for setting a light and dark Pygments theme is also based on pydata-sphinx-theme.
+- New CSS custom properties for setting light and dark responsive colours.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     "base32-lib",
     "pydantic[email]>=2.0.0",
     "beautifulsoup4",
+    "pygments",
+    "accessible-pygments",
 ]
 dynamic = ["version"]
 

--- a/src/assets/scripts/technote.js
+++ b/src/assets/scripts/technote.js
@@ -1,0 +1,73 @@
+/*
+ * Support a configurable colour theme.
+ *
+ * This script is based on pydata-sphinx-theme:
+ * https://github.com/pydata/pydata-sphinx-theme
+ */
+
+var prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+
+/**
+ * Set the the body theme to the one specified by the user's browser/system
+ * settings.
+ *
+ * @param {event} e
+ */
+function handleAutoTheme(e) {
+  document.documentElement.dataset.theme = prefersDark.matches
+    ? 'dark'
+    : 'light';
+}
+
+/**
+ * Set the theme using the specified mode.
+ *
+ * @param {str} mode - The theme mode to set. One of ["auto", "dark", "light"]
+ */
+function setTheme(mode) {
+  if (mode !== 'light' && mode !== 'dark' && mode !== 'auto') {
+    console.error(`Got invalid theme mode: ${mode}. Resetting to auto.`);
+    mode = 'auto';
+  }
+
+  var colorScheme = prefersDark.matches ? 'dark' : 'light';
+  document.documentElement.dataset.mode = mode;
+  var theme = mode == 'auto' ? colorScheme : mode;
+
+  // save mode and theme
+  localStorage.setItem('mode', mode);
+  localStorage.setItem('theme', theme);
+  console.log(`[Technote]: Changed to ${mode} mode using the ${theme} theme.`);
+
+  // add a listener if set on auto
+  prefersDark.onchange = mode == 'auto' ? handleAutoTheme : '';
+}
+
+/**
+ * add the theme listener on the btns of the navbar
+ */
+function addThemeModeListener() {
+  // the theme was set a first time using the initial mini-script
+  // running setMode will ensure the use of the dark mode if auto is selected
+  setTheme(document.documentElement.dataset.mode);
+
+  // Attach event handlers for toggling themes colors
+  // document.querySelectorAll(".theme-switch-button").forEach((el) => {
+  //   el.addEventListener("click", cycleMode);
+  // });
+}
+
+/**
+ * Execute a method if DOM has finished loading
+ *
+ * @param {function} callback the method to execute
+ */
+export function documentReady(callback) {
+  if (document.readyState != 'loading') callback();
+  else document.addEventListener('DOMContentLoaded', callback);
+}
+
+/**
+ * Add handlers.
+ */
+documentReady(addThemeModeListener);

--- a/src/assets/styles/base/_typography.scss
+++ b/src/assets/styles/base/_typography.scss
@@ -5,6 +5,7 @@ body {
   font-family: var(--tn-component-text-font-family);
   line-height: var(--tn-component-text-line-height);
   color: var(--tn-component-text-color);
+  background: var(--tn-component-text-background-color);
 }
 
 h1,
@@ -66,4 +67,8 @@ h4:hover .headerlink,
 h5:hover .headerlink,
 h6:hover .headerlink {
   visibility: visible;
+}
+
+a {
+  color: var(--tn-component-link-color);
 }

--- a/src/assets/styles/components/_sidebar-section.scss
+++ b/src/assets/styles/components/_sidebar-section.scss
@@ -2,6 +2,10 @@
   --tn-component-sidebar-header-color: var(--tn-color-neutral-600);
 }
 
+html[data-theme='dark'] {
+  --tn-component-sidebar-header-color: var(--tn-color-neutral-200);
+}
+
 .technote-sidebar-section {
   margin: 0 0 var(--tn-space-lg-fixed);
 }

--- a/src/assets/styles/components/_svg-icon.scss
+++ b/src/assets/styles/components/_svg-icon.scss
@@ -2,4 +2,5 @@
   width: 0.85em;
   height: 0.85em;
   display: inline;
+  fill: currentColor;
 }

--- a/src/assets/styles/components/_toc.scss
+++ b/src/assets/styles/components/_toc.scss
@@ -7,6 +7,11 @@
   --tn-component-toc-level-border-color: var(--tn-color-neutral-600);
 }
 
+html[data-theme='dark'] {
+  --tn-component-toc-header-color: var(--tn-color-neutral-200);
+  --tn-component-toc-level-border-color: var(--tn-color-neutral-200);
+}
+
 .technote-toc-header {
   font-size: var(--tn-component-h4-size);
   font-weight: bold;

--- a/src/assets/styles/properties/_typography.scss
+++ b/src/assets/styles/properties/_typography.scss
@@ -17,9 +17,17 @@
   --tn-component-h6-weight: bold;
 
   --tn-component-text-color: var(--tn-color-black);
+  --tn-component-link-color: var(--tn-color-blue-500);
+  --tn-component-text-background-color: var(--tn-color-white);
 
   --tn-component-text-font-family: -apple-system, BlinkMacSystemFont, Segoe UI,
     Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue,
     sans-serif;
   --tn-component-text-line-height: 1.5;
+}
+
+html[data-theme='dark'] {
+  --tn-component-text-color: var(--tn-color-white);
+  --tn-component-link-color: var(--tn-color-blue-300);
+  --tn-component-text-background-color: var(--tn-color-black);
 }

--- a/src/assets/styles/utilities/_index.scss
+++ b/src/assets/styles/utilities/_index.scss
@@ -1,3 +1,5 @@
+@use 'theme';
+
 .technote-icon-pair-list {
   list-style: none;
   margin-left: 0;

--- a/src/assets/styles/utilities/_theme.scss
+++ b/src/assets/styles/utilities/_theme.scss
@@ -1,0 +1,11 @@
+/*
+ * Utilities for displaying different elements based on the current theme.
+ */
+
+html[data-theme='light'] .technote-themed-dark {
+  display: none;
+}
+
+html[data-theme='dark'] .technote-themed-light {
+  display: none;
+}

--- a/src/technote/ext/__init__.py
+++ b/src/technote/ext/__init__.py
@@ -17,6 +17,7 @@ from .abstract import (
     visit_abstract_node_tex,
 )
 from .metadata import process_html_page_context_for_metadata
+from .pygmentscss import overwrite_pygments_css
 from .toc import process_html_page_context_for_toc
 
 __all__ = ["setup"]
@@ -37,6 +38,7 @@ def setup(app: Sphinx) -> dict[str, Any]:
     # Metadata
     app.connect("html-page-context", process_html_page_context_for_metadata)
     app.connect("html-page-context", process_html_page_context_for_toc)
+    app.connect("build-finished", overwrite_pygments_css)
 
     return {
         "version": __version__,

--- a/src/technote/ext/__init__.py
+++ b/src/technote/ext/__init__.py
@@ -40,8 +40,15 @@ def setup(app: Sphinx) -> dict[str, Any]:
     app.connect("html-page-context", process_html_page_context_for_toc)
     app.connect("build-finished", overwrite_pygments_css)
 
+    app.connect("builder-inited", _add_js_file)
+
     return {
         "version": __version__,
         "parallel_read_safe": True,
         "parallel_write_safe": True,
     }
+
+
+def _add_js_file(app: Sphinx) -> None:
+    """Add Technote's javascript to the Sphinx page."""
+    app.add_js_file("scripts/technote.js")

--- a/src/technote/ext/pygmentscss.py
+++ b/src/technote/ext/pygmentscss.py
@@ -1,0 +1,76 @@
+"""A build-finished Sphinx hook that overwrites the ppygments.css file."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+from pygments.formatters import HtmlFormatter
+from sphinx.application import Sphinx
+
+__all__ = ["overwrite_pygments_css"]
+
+
+def overwrite_pygments_css(
+    app: Sphinx, exceptions: Exception | None = None
+) -> None:
+    """Overwrite the pygments CSS file with a version that enables toggling
+    between light and dark themes.
+
+    Each selector is prefixed with html[data-theme='light|dark'] to enable
+    toggling between light and dark themes with JavaScript.
+
+    This approach is heavily based on pydata-sphinx-theme and furo:
+
+    - https://github.com/pydata/pydata-sphinx-theme/blob/main/src/pydata_sphinx_theme/pygment.py
+    - https://github.com/pradyunsg/furo/blob/main/src/furo/__init__.py
+    """
+    if exceptions:
+        return
+
+    pygment_css_path = Path(app.builder.outdir) / "_static" / "pygments.css"
+    pygments_css = _create_pygments_css()
+    pygment_css_path.write_text(pygments_css)
+
+
+def _create_pygments_css() -> str:
+    """Create the pygments CSS file that provides both light and dark themes.
+
+    Returns
+    -------
+    str
+        The custom pygments CSS contents.
+    """
+    # These Pygments styles are provided via
+    # https://pypi.org/project/accessible-pygments/
+    light_formatter = HtmlFormatter(style="github-light-high-contrast")
+    dark_formatter = HtmlFormatter(style="github-dark-high-contrast")
+
+    css_lines: list[str] = []
+    css_lines.extend(_format_css(light_formatter, "light"))
+    css_lines.extend(_format_css(dark_formatter, "dark"))
+
+    return "\n".join(css_lines) + "\n"
+
+
+def _format_css(formatter: HtmlFormatter, theme: str) -> Iterator[str]:
+    """Format pygments CSS for a given theme.
+
+    Parameters
+    ----------
+    formatter : HtmlFormatter
+        The Pygments formatter to use (which defines the theme).
+    theme : str
+        The theme name (light or dark). This sets the html[data-theme]
+        selector.
+
+    Yields
+    ------
+    str
+        A line of CSS for each selector.
+    """
+    selector_prefix = f"html[data-theme='{theme}'] .highlight"
+    for line in formatter.get_linenos_style_defs():
+        yield f"{selector_prefix} {line}"
+    yield from formatter.get_background_style_defs(selector_prefix)
+    yield from formatter.get_token_style_defs(selector_prefix)

--- a/src/technote/theme/components/sidebar-logo.html
+++ b/src/technote/theme/components/sidebar-logo.html
@@ -1,12 +1,4 @@
-{% if theme_light_logo %}
 <a href="{{ theme_logo_link_url or '#' }}">
-<picture class="technote-sidebar-logo__picture">
-  {% if theme_dark_logo %}
-  <source
-    srcset="{{ pathto('_static/' + theme_dark_logo, 1) }}"
-    media="(prefers-color-scheme: dark)">
-  {% endif %}
-  <img src="{{ pathto('_static/' + theme_light_logo, 1) }}" alt="{{theme_logo_alt_text}}">
-</picture>
+<img class="technote-themed-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" alt="{{theme_logo_alt_text}}">
+<img class="technote-themed-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" alt="{{theme_logo_alt_text}}">
 </a>
-{% endif %}

--- a/src/technote/theme/page.html
+++ b/src/technote/theme/page.html
@@ -6,7 +6,7 @@
 {% extends "layout.html" %}
 
 {% block html_tag_attrs %}
-data-theme="light"
+data-theme="light" data-mode="auto"
 {% endblock %}
 
 {% block body %}

--- a/src/technote/theme/page.html
+++ b/src/technote/theme/page.html
@@ -5,6 +5,10 @@
 
 {% extends "layout.html" %}
 
+{% block html_tag_attrs %}
+data-theme="light"
+{% endblock %}
+
 {% block body %}
 
 {% block icon_sprites %}

--- a/src/technote/theme/theme.conf
+++ b/src/technote/theme/theme.conf
@@ -1,6 +1,8 @@
 [theme]
 inherit = basic-ng
 stylesheet = styles/technote.css
+pygments_style = tango
+pygments_dark_style = monokai
 
 [options]
 light_logo =

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,10 @@ module.exports = {
   mode: 'development',
   devtool: 'source-map',
   entry: {
-    technote: ['./src/assets/styles/technote.scss'],
+    technote: [
+      './src/assets/styles/technote.scss',
+      './src/assets/scripts/technote.js',
+    ],
   },
   output: {
     filename: 'scripts/[name].js',


### PR DESCRIPTION
- Light and dark colour themes are now set via a `html[data-theme='light']` or `dark` data theme attribute. JavaScript sets this element based on the user preference of 'light', 'dark', or 'auto' (using media queries for system settings). New CSS classes `technote-themed-light` and `technote-themed-dark` now determine what elements appear, or not, in certain themed contexts. This mechanism is highly inspired by pydata-sphinx-theme.
- Pygments highlighting CSS is now applied to all code samples, with light and dark themes using the mechanism described above. The default pygments styling comes from the `accessible-pygments` package. The mechanism for setting a light and dark Pygments theme is also based on pydata-sphinx-theme.
- New CSS custom properties for setting light and dark responsive colours.
