### PR TITLE
DM-40815: Embed Highwire Press metadata tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,8 @@ clean:
 	rm -rf docs/_build
 	rm -rf docs/api
 	rm -f demo/_build
+
+.PHONY: demo
+demo:
+	npm run build
+	tox run -e demo

--- a/src/technote/config.py
+++ b/src/technote/config.py
@@ -37,6 +37,7 @@ from pydantic import (
 )
 from sphinx.errors import ConfigError
 
+from .metadata.highwire import HighwireMetadata
 from .metadata.orcid import validate_orcid_url
 from .metadata.orcid import verify_checksum as verify_orcid_checksum
 from .metadata.ror import validate_ror_url
@@ -736,3 +737,13 @@ class TechnoteJinjaContext:
     def _format_iso_date(self, date: date) -> str:
         """Format a date in ISO 8601 format."""
         return date.isoformat()
+
+    @property
+    def highwire_metadata_tags(self) -> str:
+        """The Highwire metadata tags for the technote."""
+        highwire = HighwireMetadata(
+            metadata=self.toml.technote,
+            title=self.title,
+            abstract=self.abstract,
+        )
+        return highwire.as_html()

--- a/src/technote/metadata/highwire.py
+++ b/src/technote/metadata/highwire.py
@@ -1,0 +1,135 @@
+"""Support for the Hirewire schema for academic metadata HTML in HTML."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from technote.config import TechnoteTable
+
+
+class HighwireMetadata:
+    """A class that transforms technote metadata into Highwire metadata
+    tags.
+
+    Notes
+    -----
+    Resources for learning about Highwire metadata tags:
+
+    - https://cheb.hatenablog.com/entry/2014/07/25/002548#f-c017c3cf
+    - https://scholar.google.com/intl/en/scholar/inclusion.html#indexing
+    """
+
+    def __init__(
+        self,
+        *,
+        metadata: TechnoteTable,
+        title: str,
+        abstract: str | None = None,
+    ) -> None:
+        self._metadata = metadata
+        self._title = title
+        self._abstract = abstract
+
+    def __str__(self) -> str:
+        """Create the Highwire metadata tags."""
+        return self.as_html()
+
+    def as_html(self) -> str:
+        """Create the Highwire metadata HTML tags."""
+        tags: list[str] = []
+        self.extend_not_none(tags, self.title)
+        self.extend_not_none(tags, self.author_info)
+        self.extend_not_none(tags, self.date)
+        self.extend_not_none(tags, self.doi)
+        self.extend_not_none(tags, self.technical_report_number)
+        self.extend_not_none(tags, self.html_url)
+        return "\n".join(tags) + "\n"
+
+    @staticmethod
+    def extend_not_none(
+        entries: list[str], new_item: None | str | list[str]
+    ) -> None:
+        """Extend a list with new items if they are not None."""
+        if new_item is None:
+            return
+        if isinstance(new_item, str):
+            entries.append(new_item)
+        else:
+            entries.extend(new_item)
+
+    @property
+    def title(self) -> str:
+        """The title metadata."""
+        return f'<meta name="citation_title" content="{ self._title }">'
+
+    @property
+    def author_info(self) -> list[str]:
+        """The author metadata.
+
+        Each author is represented with these tags:
+
+        - ``citation_author``
+        - ``citation_author_institution``
+        - ``citation_author_email``
+        - ``citation_author_orcid``
+        """
+        authors = self._metadata.authors
+        author_tags: list[str] = []
+        for author in authors:
+            author_tags.append(
+                self._format_tag("author", author.name.plain_text_name)
+            )
+            affil_tags = [
+                self._format_tag("author_institution", affiliation.name)
+                for affiliation in author.affiliations
+                if affiliation.name is not None
+            ]
+            author_tags.extend(affil_tags)
+            if author.email is not None:
+                author_tags.append(
+                    self._format_tag("author_email", author.email)
+                )
+            if author.orcid is not None:
+                author_tags.append(
+                    self._format_tag("author_orcid", str(author.orcid))
+                )
+        return author_tags
+
+    @property
+    def date(self) -> str | None:
+        """The ``citation_date`` metadata tag."""
+        if self._metadata.date_updated is None:
+            return None
+        iso8601_date = self._metadata.date_updated.isoformat()
+        return self._format_tag("date", iso8601_date)
+
+    @property
+    def doi(self) -> str | None:
+        """The ``citation_doi`` metadata tag."""
+        if self._metadata.doi is None:
+            return None
+        return self._format_tag("doi", str(self._metadata.doi))
+
+    @property
+    def technical_report_number(self) -> str | None:
+        """The ``citation_technical_report_number`` metadata tag."""
+        if self._metadata.id is None:
+            return None
+        return self._format_tag("technical_report_number", self._metadata.id)
+
+    @property
+    def html_url(self) -> str | None:
+        """The ``citation_fulltext_html_url`` metadata tag."""
+        if self._metadata.canonical_url is None:
+            return None
+        return self._format_tag(
+            "fulltext_html_url", str(self._metadata.canonical_url)
+        )
+
+    def _format_tag(self, name: str, content: str) -> str:
+        """Format a Highwire metadata tag."""
+        return (
+            f'<meta name="citation_{ name }" content="{ content }" '
+            f'data-highwire="true">'
+        )

--- a/src/technote/theme/page.html
+++ b/src/technote/theme/page.html
@@ -9,6 +9,11 @@
 data-theme="light" data-mode="auto"
 {% endblock %}
 
+{% block head_extra %}
+{{ super() }}
+{{ technote.highwire_metadata_tags }}
+{% endblock head_extra %}
+
 {% block body %}
 
 {% block icon_sprites %}

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -1,0 +1,42 @@
+"""Test the representation of metadata in the generated site."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import IO, Any
+
+import lxml.html
+import pytest
+from sphinx.application import Sphinx
+from sphinx.util import logging
+
+
+@pytest.mark.sphinx("html", testroot="metadata-basic")
+def test_metadata_basic(app: Sphinx, status: IO, warning: IO) -> None:
+    """Test against the ``test-metadata-basic`` test root for metadata
+    representation.
+    """
+    app.verbosity = 2
+    logging.setup(app, status, warning)
+    app.builder.build_all()
+
+    html_source = Path(app.outdir).joinpath("index.html").read_text()
+    doc = lxml.html.document_fromstring(html_source)
+    assert_tag(doc, "citation_title", "Metadata test document")
+    assert_tag(doc, "citation_date", "2023-09-19")
+    assert_tag(doc, "citation_technical_report_number", "TEST-000")
+    assert_tag(
+        doc, "citation_fulltext_html_url", "https://test-000.example.com/"
+    )
+    assert_tag(doc, "citation_author", "Jonathan Sick")
+    assert_tag(
+        doc, "citation_author_orcid", "https://orcid.org/0000-0003-3001-676X"
+    )
+    assert_tag(doc, "citation_author_institution", "Rubin Observatory")
+
+
+def assert_tag(doc: Any, name: str, content: str, index: int = 0) -> None:
+    """Compare the content of a meta tag."""
+    assert (
+        doc.cssselect(f"meta[name='{name}']")[index].get("content") == content
+    )

--- a/tests/roots/test-metadata-basic/conf.py
+++ b/tests/roots/test-metadata-basic/conf.py
@@ -1,0 +1,1 @@
+from technote.sphinxconf import *  # noqa: F403

--- a/tests/roots/test-metadata-basic/index.rst
+++ b/tests/roots/test-metadata-basic/index.rst
@@ -1,0 +1,14 @@
+######################
+Metadata demonstration
+######################
+
+.. abstract::
+
+   First paragraph of abstract.
+
+   Second paragraph of abstract.
+
+Section one
+===========
+
+Lorem ipsum.

--- a/tests/roots/test-metadata-basic/technote.toml
+++ b/tests/roots/test-metadata-basic/technote.toml
@@ -1,0 +1,13 @@
+[technote]
+id = "TEST-000"
+series_id = "TEST"
+title = "Metadata test document"
+date_updated = "2023-09-19"
+canonical_url = "https://test-000.example.com/"
+
+[[technote.authors]]
+name = { given_names = "Jonathan", family_names = "Sick" }
+orcid = "https://orcid.org/0000-0003-3001-676X"
+affiliations = [
+    { name = "Rubin Observatory", ror = "https://ror.org/048g3cy84" }
+]

--- a/tox.ini
+++ b/tox.ini
@@ -61,4 +61,4 @@ setenv =
     GITHUB_REF_TYPE = branch
 commands =
     rm -rf demo/_build
-    sphinx-build --keep-going -n -W -T -b html -d {envtmpdir}/doctrees demo demo/_build/html
+    sphinx-build --keep-going -n -W -v -T -b html -d {envtmpdir}/doctrees demo demo/_build/html


### PR DESCRIPTION
This generator creates HTML meta tags for the highwire metadata spec. It's available from the Jinja context as technote.highwire_metadata_tags

For more information on highwire tags see:

- https://cheb.hatenablog.com/entry/2014/07/25/002548#f-c017c3cf
- https://scholar.google.com/intl/en/scholar/inclusion.html#indexing

We're using the data-highwire="true" attribute because ADS also uses this, though it may not be necessary.