### PR TITLE
DM-40815: Move docs dependencies out of pyproject.toml

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,0 +1,5 @@
+# Documentation dependencies are maintained here rather than in
+# the pyproject.toml dev extras to avoid circular dependencies with the
+# documenteer packaging.
+documenteer[guide] @ git+https://github.com/lsst-sqre/documenteer@main
+autodoc_pydantic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,6 @@ dev = [
     "lxml",
     "cssselect",
     "mf2py",
-    # Documentation
-    "documenteer[guide] @ git+https://github.com/lsst-sqre/documenteer@main",
-    "autodoc_pydantic",
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,8 @@ allowlist_externals =
     rm
     cp
     mkdir
+deps =
+    -r docs-requirements.txt
 commands =
     sphinx-build --keep-going -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
     rm -rf docs/_build/html/demo
@@ -49,6 +51,8 @@ commands =
 
 [testenv:docs-linkcheck]
 description = Check links in the documentation.
+deps =
+    -r docs-requirements.txt
 commands =
     sphinx-build --keep-going -n -T -b linkcheck -d {envtmpdir}/doctrees docs docs/_build/linkcheck
 


### PR DESCRIPTION
I find that specifying documenteer from GitHub in technote's dev extras prevents a release to PyPI because documenteer also dependends on technote. This PR breaks that circularity by moving the documentation dependencies into a docs-requirements.txt file that tox installs.