### PR TITLE
DM-40815: Ensure assets are built for PyPI package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,16 @@ jobs:
       - name: Install Graphviz
         run: sudo apt-get install graphviz
 
+      - uses: actions/setup-node@v3
+        with:
+          cache: 'npm'
+          node-version-file: '.nvmrc'
+
+      - name: npm install and build
+        run: |
+          npm install
+          npm run build
+
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
         with:
@@ -125,6 +135,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history for setuptools_scm
+
+      - uses: actions/setup-node@v3
+        with:
+          cache: 'npm'
+          node-version-file: '.nvmrc'
+
+      - name: npm install and build
+        run: |
+          npm install
+          npm run build
 
       - name: Build and publish
         uses: lsst-sqre/build-and-publish-to-pypi@v2


### PR DESCRIPTION
`npm run build` must be run to create the CSS and JS assets that are included in the docs build. We do that now.