### PR TITLE
DM-40847: Fix the link rel=canonical tag

### DIFF
--- a/changelog.d/20230925_150207_jsick_DM_40847.md
+++ b/changelog.d/20230925_150207_jsick_DM_40847.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fixed the `link` `rel=canonical` tag in the header; previously the URL was set to the `content` attribute instead of the `href` attribute.

--- a/src/technote/theme/page.html
+++ b/src/technote/theme/page.html
@@ -15,7 +15,7 @@ data-theme="light" data-mode="auto"
 <meta name="description" content="{{ technote.abstract }}">
 {% endif %}
 {% if technote.canonical_url %}
-<link rel="canonical" content="{{ technote.canonical_url }}">
+<link rel="canonical" href="{{ technote.canonical_url }}">
 {% endif %}
 {{ technote.generator_tag }}
 {{ technote.opengraph_metadata_tags }}

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -63,7 +63,7 @@ def test_metadata_basic(app: Sphinx, status: IO, warning: IO) -> None:
         == "First paragraph of abstract.\n\nSecond paragraph of abstract."
     )
     assert (
-        doc.cssselect("link[rel='canonical']")[0].get("content")
+        doc.cssselect("link[rel='canonical']")[0].get("href")
         == "https://test-000.example.com/"
     )
     found_technote_generator = False


### PR DESCRIPTION
Fixed the `link` `rel=canonical` tag in the header; previously the URL was set to the `content` attribute instead of the `href` attribute.