### PR TITLE
DM-40926: Make the left and right sidebars sticky

### DIFF
--- a/changelog.d/20230927_144200_jsick_DM_40926.md
+++ b/changelog.d/20230927_144200_jsick_DM_40926.md
@@ -1,0 +1,17 @@
+<!-- Delete the sections that don't apply -->
+
+### Backwards-incompatible changes
+
+-
+
+### New features
+
+- Improve styling of the local table of contents. The outline is now sticky to the document and is independently scrollable if longer than the viewport.
+
+### Bug fixes
+
+-
+
+### Other changes
+
+-

--- a/changelog.d/20230927_144200_jsick_DM_40926.md
+++ b/changelog.d/20230927_144200_jsick_DM_40926.md
@@ -1,17 +1,4 @@
-<!-- Delete the sections that don't apply -->
-
-### Backwards-incompatible changes
-
--
-
 ### New features
 
 - Improve styling of the local table of contents. The outline is now sticky to the document and is independently scrollable if longer than the viewport.
-
-### Bug fixes
-
--
-
-### Other changes
-
--
+- The content in the primary (left) sidebar is also sticky to the document and is independently scrollable if longer than the viewport.

--- a/src/assets/styles/base/_layout.scss
+++ b/src/assets/styles/base/_layout.scss
@@ -94,7 +94,6 @@
   } */
 }
 @media (min-width: 50rem) {
-  /* secondary sidebar appears, width is 17rem. */
   .sb-footer-content__inner,
   .drop-secondary-sidebar-for-full-width-content .sb-article,
   .drop-secondary-sidebar-for-full-width-content .match-content-width {
@@ -109,6 +108,7 @@
   } */
 }
 @media (min-width: 59rem) {
+  /* secondary sidebar appears, width is 17rem. */
   .sb-footer-content__inner,
   .drop-secondary-sidebar-for-full-width-content .sb-article,
   .drop-secondary-sidebar-for-full-width-content .match-content-width {

--- a/src/assets/styles/components/_index.scss
+++ b/src/assets/styles/components/_index.scss
@@ -1,5 +1,6 @@
 @use 'article-header';
 @use 'icon-metadata';
+@use 'sidebar';
 @use 'sidebar-section';
 @use 'sidebar-logo';
 @use 'svg-icon';

--- a/src/assets/styles/components/_sidebar.scss
+++ b/src/assets/styles/components/_sidebar.scss
@@ -1,0 +1,14 @@
+/* The container for the primary sidebar */
+
+@media (min-width: 76rem) {
+  .technote-sidebar-container {
+    // Make the primary sidebar's content's sticky to the top of the page
+    // when visible.
+    position: sticky;
+    top: 1rem;
+
+    // Allow the sidebar content to scroll when necessary
+    overflow-y: auto;
+    max-height: 100vh;
+  }
+}

--- a/src/assets/styles/components/_toc.scss
+++ b/src/assets/styles/components/_toc.scss
@@ -12,13 +12,33 @@ html[data-theme='dark'] {
   --tn-component-toc-level-border-color: var(--tn-color-neutral-200);
 }
 
+.technote-toc {
+  // Ensure that the toc can scroll independently if its longer than the viewport
+  overflow-y: auto;
+  max-height: 100vh;
+}
+
+@media (min-width: 59rem) {
+  // technote-toc is now a part of the page, not a slide-out
+  .technote-toc {
+    // make the toc sticky relative to the top of the page
+    position: sticky;
+    top: 1rem;
+
+    // This makes the outline float midway down the page in a sort of useful
+    // position. It could definitely be engineered better.
+    margin-top: 20vh;
+
+    // give the toc more margin to the content
+    margin-left: 2rem;
+  }
+}
+
 .technote-toc-header {
+  margin: 0 0 1rem;
   font-size: var(--tn-component-h4-size);
   font-weight: bold;
   color: var(--tn-component-toc-header-color);
-  // This makes the outline float midway down the page in a sort of useful
-  // position. It could definitely be engineered better.
-  margin-top: 20vh;
 }
 
 .technote-toc-container {

--- a/src/technote/theme/components/sidebar-toc.html
+++ b/src/technote/theme/components/sidebar-toc.html
@@ -1,5 +1,7 @@
-<h2 class="technote-toc-header">Outline</h2>
+<nav class="technote-toc">
+  <h2 class="technote-toc-header">Outline</h2>
 
-<div class="technote-toc-container">
-  {{ technote_toc }}
-</div>
+  <div class="technote-toc-container">
+    {{ technote_toc }}
+  </div>
+</nav>

--- a/src/technote/theme/sections/sidebar-primary.html
+++ b/src/technote/theme/sections/sidebar-primary.html
@@ -1,3 +1,4 @@
+<div class="technote-sidebar-container">
 {% include "components/sidebar-logo.html" %}
 
 {% include "components/sidebar-authors.html" %}
@@ -5,3 +6,4 @@
 {% include "components/sidebar-version.html" %}
 
 {% include "components/sidebar-source.html" %}
+</div>


### PR DESCRIPTION
Make the content of both sidebar sticky when visible on page and also allow them to independently scroll if longer than the viewport. This is useful for accessing the document outline, for example.