### PR TITLE
DM-41046: Show the document's status

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include src/technote/theme/static/styles/technote.css
 include src/technote/theme/static/styles/technote.css.map
 include src/technote/theme/static/scripts/technote.js
+include src/technote/ext/templates/*.html.jinja
 prune src/assets

--- a/changelog.d/20231004_162609_jsick_DM_41046.md
+++ b/changelog.d/20231004_162609_jsick_DM_41046.md
@@ -1,0 +1,7 @@
+### Backwards-incompatible changes
+
+- The `technote.status` field is changed. The "planning" and "active" states are now "draft." The values in the `supersceding_urls` array are now tables with `url` and `title` (optional) keys.
+
+### New features
+
+- The new "insertstatus" Sphinx extension, included in the `technote.ext` Sphinx extension, inserts an aside element below the title of the technote describing the status. The status is only published for non-stable states.

--- a/demo/technote.toml
+++ b/demo/technote.toml
@@ -14,3 +14,14 @@ orcid = "https://orcid.org/0000-0003-3001-676X"
 affiliations = [
     { name = "Rubin Observatory", ror = "https://ror.org/048g3cy84" }
 ]
+
+[technote.status]
+state = "deprecated"
+note = "This is a comment about the status of this document."
+
+[[technote.status.supersceding_urls]]
+url = "https://sqr-000.lsst.io/"
+title = "The technical note system"
+
+[[technote.status.supersceding_urls]]
+url = "https://sqr-006.lsst.io/"

--- a/src/assets/styles/components/_index.scss
+++ b/src/assets/styles/components/_index.scss
@@ -3,5 +3,6 @@
 @use 'sidebar';
 @use 'sidebar-section';
 @use 'sidebar-logo';
+@use 'status';
 @use 'svg-icon';
 @use 'toc';

--- a/src/assets/styles/components/_status.scss
+++ b/src/assets/styles/components/_status.scss
@@ -1,0 +1,19 @@
+/* Styles for the document status aside */
+
+.technote-status {
+  border: 1px solid var(--tn-component-text-color);
+  padding: 1rem;
+  border-radius: var(--tn-border-radius-1);
+}
+
+.technote-status--deprecated {
+  border-color: var(--tn-color-red-500);
+}
+
+.technote-status p:first-of-type {
+  margin-top: 0;
+}
+
+.technote-status *:last-child {
+  margin-bottom: 0;
+}

--- a/src/technote/config.py
+++ b/src/technote/config.py
@@ -363,6 +363,17 @@ class TechnoteState(str, Enum):
     """
 
 
+class Link(BaseModel):
+    """A model for a web link."""
+
+    url: HttpUrl = Field(description="The URL of the link.")
+
+    title: str | None = Field(
+        None,
+        description="The title of the link, if available.",
+    )
+
+
 class TechnoteStatus(BaseModel):
     """A model for the technote's status.
 
@@ -378,7 +389,7 @@ class TechnoteStatus(BaseModel):
 
     note: str | None = Field(None, description="An explanation of the state.")
 
-    supersceding_urls: list[HttpUrl] = Field(
+    supersceding_urls: list[Link] = Field(
         default_factory=list,
         description=(
             "URLs to documents/webpages that superscede this technote."

--- a/src/technote/config.py
+++ b/src/technote/config.py
@@ -336,19 +336,13 @@ class TechnoteState(str, Enum):
     .. mermaid::
 
        flowchart LR
-         planning --> active
-         active --> stable
-         stable --> active
+         draft --> stable
+         stable --> draft
          stable --> deprecated
-         active --> deprecated
+         draft --> deprecated
     """
 
-    planning = "planning"
-    """The technote is being researched and planned, but may not have useful
-    content yet.
-    """
-
-    active = "active"
+    draft = "draft"
     """The technote is being actively drafted and updated. It may not be
     complete.
     """

--- a/src/technote/ext/__init__.py
+++ b/src/technote/ext/__init__.py
@@ -16,6 +16,7 @@ from .abstract import (
     visit_abstract_node_html,
     visit_abstract_node_tex,
 )
+from .insertstatus import insert_status
 from .metadata import process_html_page_context_for_metadata
 from .pygmentscss import overwrite_pygments_css
 from .toc import process_html_page_context_for_toc
@@ -39,11 +40,12 @@ def setup(app: Sphinx) -> dict[str, Any]:
     # Metadata
     app.connect("html-page-context", process_html_page_context_for_metadata)
     app.connect("html-page-context", process_html_page_context_for_toc)
-    app.connect("build-finished", overwrite_pygments_css)
 
     app.connect("builder-inited", _add_js_file)
 
     app.connect("build-finished", wrap_html_tables)
+    app.connect("build-finished", insert_status)
+    app.connect("build-finished", overwrite_pygments_css)
 
     return {
         "version": __version__,

--- a/src/technote/ext/insertstatus.py
+++ b/src/technote/ext/insertstatus.py
@@ -1,0 +1,48 @@
+"""Inserts the status of the technote below thte h1."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from bs4 import BeautifulSoup
+from jinja2 import Environment, PackageLoader, select_autoescape
+from sphinx.application import Sphinx
+
+from ..config import TechnoteState, TechnoteStatus
+
+
+def insert_status(app: Sphinx, exceptions: Exception | None) -> None:
+    """Insert a status aside into the technote, directly below the title.
+
+    The status aside is only added for non-stable states (draft, deprecated,
+    or other).
+    """
+    if exceptions:
+        return
+
+    try:
+        technote_config = app.config.html_context["technote"]
+    except (KeyError, AttributeError):
+        return
+
+    status = technote_config.toml.technote.status
+    status = cast(TechnoteStatus, status)
+    if status.state == TechnoteState.stable:
+        return
+
+    # Load template from templates/status.html.jinja
+    jinja_env = Environment(
+        loader=PackageLoader("technote", "ext/templates"),
+        autoescape=select_autoescape(["html"]),
+    )
+    template = jinja_env.get_template("status.html.jinja")
+    status_html = template.render(status=status)
+    status_soup = BeautifulSoup(status_html, "html.parser")
+
+    # Insert the status aside into the technote
+    html_path = Path(app.builder.outdir) / "index.html"
+    soup = BeautifulSoup(html_path.read_text(), "html.parser")
+    title = soup.find("h1")
+    title.insert_after(status_soup)
+    html_path.write_text(str(soup))

--- a/src/technote/ext/templates/status.html.jinja
+++ b/src/technote/ext/templates/status.html.jinja
@@ -1,0 +1,31 @@
+<aside class="technote-status technote-status--{{ status.state.value }}">
+  <p class="technote-status__note" data-technote-status="{{ status.state.value }}">
+  {% if status.state == "draft" %}
+  This is a draft.
+  {% if status.note %}
+  {{ status.note }}
+  {% endif %}
+  </p>
+
+  {% elif status.state == "deprecated" %}
+  This document is deprecated.
+  {% if status.note %}
+  {{ status.note }}
+  {% endif %}
+  </p>
+
+  {% if status.supersceding_urls %}
+  <p>See instead:</p>
+
+  <ul>
+  {% for link in status.supersceding_urls %}
+    <li><a href="{{ link.url }}" class="technote-superceding-url">{{ link.title or link.url }}</a></li>
+  {% endfor %}
+  </ul>
+  {% endif %}
+
+  {% elif status.state == "other" %}
+  {{ status.note }}
+  </p>
+  {% endif %}
+</aside>


### PR DESCRIPTION
The new "insertstatus" Sphinx extension, included in the `technote.ext` Sphinx extension, inserts an aside element below the title of the technote describing the status. The status is only published for non-stable states.

The HTML for the status is marked up so it's easy to extract data about the status
    
- on the `aside`, the `data-technote-status data attribute` describes the status
- The note is marked up with "technote-status__note"
- Supersceding URLs are marked up with "technote-supersceding-url"

The `technote.status` field has also changed. The "planning" and "active" states are now "draft." The values in the `supersceding_urls` array are now tables with `url` and `title` (optional) keys.