### PR TITLE
DM-41537: Add docs on technote configuration

### DIFF
--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -6,6 +6,8 @@
 .. _pytest: https://docs.pytest.org/en/latest/
 .. _tox: https://tox.wiki/en/latest/
 .. _Click: https://click.palletsprojects.com/
+.. _Intersphinx: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
+.. _Sphinx: https://www.sphinx-doc.org/
 
 .. Badges
 

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -8,6 +8,7 @@
 .. _Click: https://click.palletsprojects.com/
 .. _Intersphinx: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
 .. _Sphinx: https://www.sphinx-doc.org/
+.. _TOML: https://toml.io/en/
 
 .. Badges
 

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -1,6 +1,13 @@
 
+.. Links
+
 .. _mypy: http://www.mypy-lang.org
 .. _pre-commit: https://pre-commit.com
 .. _pytest: https://docs.pytest.org/en/latest/
 .. _tox: https://tox.wiki/en/latest/
 .. _Click: https://click.palletsprojects.com/
+
+.. Badges
+
+.. |required| replace:: :bdg-primary-line:`Required`
+.. |optional| replace:: :bdg-secondary-line:`Optional`

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -9,6 +9,7 @@
 .. _Intersphinx: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
 .. _Sphinx: https://www.sphinx-doc.org/
 .. _TOML: https://toml.io/en/
+.. _Documenteer: https://documenteer.lsst.io/
 
 .. Badges
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -48,3 +48,5 @@ Python API reference
 
 .. automodapi:: technote.metadata.zenodo
    :include-all-objects:
+
+.. automodapi:: technote.sources.tomlsettings

--- a/docs/dev/development.rst
+++ b/docs/dev/development.rst
@@ -138,8 +138,6 @@ Building documentation
 
 Documentation is built with Sphinx_, sourced from the :file:`docs` directory:
 
-.. _Sphinx: https://www.sphinx-doc.org/en/master/
-
 .. code-block:: sh
 
    tox -e docs

--- a/docs/user-guide/configuration-overview.rst
+++ b/docs/user-guide/configuration-overview.rst
@@ -1,0 +1,92 @@
+##################################
+Overview of technote configuration
+##################################
+
+Technote builds technote documents using Sphinx_.
+Virtually anything you can accomplish in a general Sphinx project your can also include in a technote.
+To simplify the set up process, Technote provides its own configuration system that layers on top of Sphinx's.
+This page explains that configuration system.
+
+The technote.toml and conf.py files
+===================================
+
+Besides the content file, technotes have at least two other files: :file:`technote.toml` and :file:`conf.py`.
+
+:file:`technote.toml` is unique to Technote, and is what you'll work with most often.
+This file is where you can both mark up bibliographic metadata about your technote and also configure the Sphinx_ build.
+A basic :file:`technote.toml` file might look like this:
+
+.. literalinclude:: ../../demo/rst/technote.toml
+   :caption: conf.py
+
+To learn about all the available keys in :file:`technote.toml`, see :doc:`technote-toml`.
+This user guide also includes a number of :ref:`how-to guides on specific aspects of the configuration <toc-config>`.
+
+The other configuration file is :file:`conf.py` — the standard Sphinx configuration file.
+At a minimum, the Sphinx configuration imports the base technote configuration:
+
+.. code-block:: python
+   :caption: conf.py
+
+   from technote.sphinxconf import *
+
+If you are using a theme for an organization, you will import *its* configuration module instead.
+For example, Rubin technote use a configuration from `Documenteer <https://documenteer.lsst.io>`_:
+
+.. code-block:: python
+   :caption: conf.py
+
+   from documenteer.conf.technote import *
+
+Primer on TOML
+==============
+
+:file:`technote.toml` is written in TOML_ syntax.
+If you've written YAML before, you'll be fairly comfortable, but TOML does have a number of distinct features.
+The first unique feature to note is that mappings or objects (key-value pairs) are described with *tables* and those tables are preceded by their key in square brackets.
+
+.. code-block:: toml
+
+   [technote]  # the technote table
+   id = "SQR-000"  # a key in the table, aka technote.id
+
+Tables can be nested.
+For example, the ``sphinx`` table inside the ``technote`` table:
+
+.. code-block:: toml
+
+   [technote.sphinx]
+   extensions = ["sphinx_diagrams"]
+
+TOML supports resolving keys in tables using dots (``.``) to separate each level of hierarchy.
+So the same TOML configuration as above can be expressed as:
+
+.. code-block:: toml
+
+   [technote]
+   sphinx.extensions = ["sphinx_diagrams"]
+
+The :file:`technote.toml` configuration frequently uses *arrays of tables*, such as when listing authors.
+Arrays of tables are the key name, in double brackets.
+You can repeat the tables for each item:
+
+.. code-block:: toml
+
+   [[technote.authors]]
+   name.given = "Jonathan"
+   name.family = "Sick"
+
+   [[technote.authors]]
+   name.given = "Frossie"
+   name.family = "Economou"
+
+To learn all about the TOML syntax, see the `TOML specification website`__.
+
+How the configuration system works with the Sphinx build
+========================================================
+
+If your are curious how the Sphinx build uses :file:`technote.toml`,
+
+When a Sphinx build starts (by running ``sphinx-build``), it automatically reads the project's configuration file (:file:`conf.py`).
+In technote projects, the :file:`conf.py` file always imports the base technote configuration module, either directly or through a theme's configuration file (``from technote.sphinxconf import *``).
+The Technote configuration module, in turn, loads :file:`technote.toml` and then sets Sphinx configuration variables based on that input.

--- a/docs/user-guide/configure-authors.rst
+++ b/docs/user-guide/configure-authors.rst
@@ -1,0 +1,119 @@
+####################################################
+Specifying authors and contributors in technote.toml
+####################################################
+
+The :file:`technote.toml` file is where you specify the authors and other contributors to a technote.
+This metadata is the basis for the author list in the technote's HTML and in :doc:`metadata exported <metadata>` from the technote HTML.
+For a full reference of the schema for listing authors in :file:`technote.toml`, see :ref:`toml-technote-authors` and :ref:`toml-technote-contributors`.
+
+Minimal author metadata
+=======================
+
+At a minimum, an author has a name.
+To make metadata export more precise, the preferred markup is to define both the given (first) and family (last) names:
+
+.. code-block:: toml
+
+   [[technote.authors]]
+   name = { "given_names": "Vera", "family_names": "Rubin" }
+
+
+Alternatively, the name can be an unstructured string:
+
+.. code-block:: toml
+
+   [[technote.authors]]
+   name = { "name": "Vera C. Rubin" }
+
+``name`` is just one of many keys in a ``[[technote.authors]]`` table; documentation of how to add additional metadata are provided below.
+
+Multiple authors
+================
+
+To add multiple authors, add extra ``[[technote.authors]]`` tables.
+In TOML, the ``[[ ]]`` indicates an **array** of tables.
+
+.. code-block:: toml
+
+   [[technote.authors]]
+   name = { "given_names": "Arno A.", "family_names": "Penzias" }
+
+   [[technote.authors]]
+   name = { "given_names": "Robert W.", "family_names": "Wilson" }
+
+Each author can have rich metadata, as described next.
+
+Additional author metadata
+==========================
+
+Besides the ``name`` key, authors can have additional metadata (see the :ref:`[[technote.authors]] <toml-technote-authors>` reference).
+The author's email, ORCiD identifier, an internal identifier, and affiliations can be added.
+
+.. code-block:: toml
+
+   [[technote.authors]]
+   name = { "given_names": "Jonathan", "family_names": "Sick" }
+   email = "jsick@lsst.org"
+   orcid = "https://orcid.org/0000-0003-3001-676X"
+   internal_id = "sickj"
+
+Note that any of these additional fields can be omitted if the metadata isn't available or appropriate.
+
+The ``orcid`` field, if set, must be a full URL, not just the path component of the ORCiD.
+
+The ``internal_id`` is meant to have meaning within the specific organization authoring technotes.
+For example, Rubin Observatory keeps a database of authors.
+Including the ``internal_id`` enables Rubin to automatically update and augment metadata in individual technotes based on that author database.
+
+Adding affiliations
+===================
+
+A ``[[technote.authors]]`` table can include an array of affiliations tables.
+These tables can be inline, if brief:
+
+.. code-block:: toml
+
+   [[technote.authors]]
+   name = { given_names = "Jonathan", family_names = "Sick" }
+   orcid = "https://orcid.org/0000-0003-3001-676X"
+   affiliations = [
+       { name = "J.Sick Codes" }
+       { name = "Rubin Observatory", ror = "https://ror.org/048g3cy84" }
+   ]
+
+Or as full ``[[technote.authors.affiliations]]`` tables:
+
+.. code-block:: toml
+
+   [[technote.authors]]
+   name = { given_names = "Jonathan", family_names = "Sick" }
+   orcid = "https://orcid.org/0000-0003-3001-676X"
+
+   [[technote.authors.affiliations]]
+   name = "J.Sick Codes"
+
+   [[technote.authors.affiliations]]
+   name = "Rubin Observatory", ror = "https://ror.org/048g3cy84" }
+   ]
+
+Non-author contributors
+=======================
+
+People other than authors might contribute to a technote.
+For example, a contact, an editor, or a project manager.
+Each non-author contributor can be marked up with a specific role.
+
+Each contributor
+To start, each contributor is a ``[[technote.contributors]]`` table.
+Contributors take the same keys as authors (``[[technote.authors]]``), but with additional ``role`` and ``note`` fields.
+
+The ``role`` can be any string from the Zenodo vocabulary for roles (`technote.metadata.zenodo.ZenodoRole`).
+
+.. code-block:: toml
+
+   [[technote.contributors]]
+   name.given_names = "Frossie"
+   name.family_names = "Economou"
+   role = "ProjectManager"
+
+For the ``Other`` role, you can clarify it with a free-form text statement in the ``note`` key.

--- a/docs/user-guide/configure-sphinx.rst
+++ b/docs/user-guide/configure-sphinx.rst
@@ -1,0 +1,120 @@
+############################
+Configuring the Sphinx build
+############################
+
+Technote builds upon Sphinx_.
+This means that any Sphinx syntax and extensions are available to technotes.
+Although Technote has its own default configurations for the Sphinx build, you can customize some common Sphinx configurations in the :file:`technote.toml` file, or by directly editing the :file:`conf.py` file.
+
+Adding Sphinx extensions
+========================
+
+The most common configuration is to add additional Sphinx extensions.
+You can do this with the ``extensions`` key in the ``[technote.sphinx]`` table:
+
+.. code-block:: toml
+   :caption: technote.toml
+
+   [technote.sphinx]
+   extensions = ["sphinx_diagrams"]
+
+Note that these extensions are *in addition* to the default extensions provided by Technote and any custom theme.
+
+Once added through the ``extensions`` array in :file:`technote.toml`, you can add configurations for that extension in the Sphinx :file:`conf.py` file.
+See :ref:`direct-sphinx-conf`.
+
+.. important::
+
+   Remember to also install the extension, as necessary.
+   This might be done by adding the extension's package to your :file:`requirements.txt` file, or similar.
+
+Link to other documentation with intersphinx
+============================================
+
+Intersphinx_ is a built-in Sphinx extension that helps you link to other sphinx projects (including other technotes and many Python project documentation sites including `docs.astropy.org <https://docs.astropy.org/en/stable/>`__ and `docs.python.org <https://docs.python.org/3/>`__.)
+
+To add a site to the Intersphinx_ configuration, add items to the ``[technote.sphinx.intersphinx]`` table:
+
+.. code-block:: toml
+   :caption: technote.toml
+
+   [technote.sphinx.intersphinx]
+   astropy = "https://docs.astropy.org/en/stable/"
+   python = "https://docs.python.org/3/"
+
+Keys are the names of projects, and also become prefixes for ``ref`` directives to that project.
+
+For information on using Intersphinx_ to make cross-project links, see the `Sphinx documentation <https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>`__.
+
+Configuring the "nitpick" settings
+==================================
+
+Sphinx's "nitpick" mode elevates build warnings into errors.
+You might want to enable this mode if you want catch any issues in your documents build.
+Technote doesn't enable nitpick mode by default because it can be challenging to understand some types of Sphinx warnings.
+
+To enable nitpick mode:
+
+.. code-block:: toml
+   :caption: technote.toml
+
+   [technote.sphinx]
+   nitpick = true
+
+If some types of errors are unavoidable, you can configure Sphinx to ignore them.
+Errors in Sphinx have types (e.g. the ``py:obj`` role) and targets (the argument of the role).
+For example, to ignore all errors related to FastAPI API links:
+
+.. code-block:: toml
+   :caption: technote.toml
+
+   [technote.sphinx]
+   nitpick = true
+   nitpick_ignore_regex = [
+     ['py:obj', 'fastapi\.*']
+   ]
+
+This regex syntax allows you to match multiple types and targets.
+Use TOML's literal string syntax (single quotes, rather than double quotes) to avoid escaping backslashes.
+An alternative key, ``nitpick_ignore``, is available is you don't need to use regular expression syntax.
+
+See the `Sphinx nitpick configuration documentation <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-nitpick_ignore>`__ for more details.
+
+Configuring the linkcheck builder
+=================================
+
+Sphinx's linkcheck builder allows you to verify that links in your technote are resolvable on the internet.
+Some links may be inherently unresolvable (because of auth), or be known to be intermittently unavailable.
+You can ignore such links with the ``[technote.sphinx.linkcheck]`` table's ``ignore`` array.
+
+.. code-block:: toml
+   :caption: technote.toml
+
+   [technote.sphinx.linkcheck]
+   ignore = [
+     'https://docushare\.lsstcorp\.org/.*'
+   ]
+
+Items in the ``ignore`` array are interpreted as Python regular expressions.
+Therefore, use single quotes for a literal TOML string to avoid escaping backslashes.
+
+For more information, see `the Sphinx linkcheck configuration documentation <https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder>`__.
+
+.. _direct-sphinx-conf:
+
+Directly configuring Sphinx and extensions
+==========================================
+
+Sphinx and its extensions take configurations beyond those accessible from the :file:`technote.toml` file.
+You can still make those configurations in the :file:`conf.py` file.
+
+.. code-block:: python
+   :caption: conf.py
+
+   from technote.sphinxconf import *  # noqa: F403
+
+   primary_domain = "math"
+
+Generally add your configurations *after* the base technote configuration is imported (i.e., after ``from technote.sphinxconf import *``, or your theme's equivalent) to override any default configurations.
+
+For more information about Sphinx configurations, see the `Sphinx documentation <https://www.sphinx-doc.org/en/master/usage/configuration.html>`__ or the documentation for an extension.

--- a/docs/user-guide/configure-status.rst
+++ b/docs/user-guide/configure-status.rst
@@ -1,0 +1,74 @@
+#############################################################
+Describing the document status (draft, deprecated, or stable)
+#############################################################
+
+Technotes are continuously updated on the web as you add commits and merge pull requests.
+Your "drafts" are visible to the rest of the observatory, and even the public, to speed up collaboration and provide transparency.
+You can communicate the status of the document by setting metadata in :file:`technote.toml`.
+For example, you can specify that the technote is an incomplete draft, or that the technote is deprecated and is now replaced by another set of documents.
+This configuration is optional; the default status is "stable" when the ``[technote.status]`` table is omitted.
+
+Setting "draft" status
+======================
+
+If the technote is incomplete and being actively written, you can set the status to "draft:"
+
+.. code-block:: toml
+   :caption: technote.toml
+
+   [technote.status]
+   state = "draft"
+
+Setting "stable" status
+=======================
+
+If the technote is complete, accurate and no longer being actively worked upon, you can set the status to "stable:"
+
+.. code-block:: toml
+   :caption: technote.toml
+
+   [technote.status]
+   state = "stable"
+
+This is the default state if one is not specified in :file:`technote.toml`.
+
+Setting "deprecated" status
+===========================
+
+If your technote is no longer accurate or relevant, you can mark it as deprecated:
+
+.. code-block:: toml
+   :caption: technote.toml
+
+   [technote.status]
+   state = "deprecated"
+   note = "This technote is deprecated because [...]"
+
+If the technote has been replaced by one or more other documents, you can link to them with a ``supersceding_urls`` array:
+
+.. code-block:: toml
+   :caption: technote.toml
+
+   [technote.status]
+   state = "deprecated"
+   note = "This technote is deprecated because [...]"
+
+   [[technote.status.supersceding_urls]]
+   title = "New technote"
+   url = "https://example.lsst.io/"
+
+   [[technote.status.supersceding_urls]]
+   title = "Another document"
+   url = "https://example-two.lsst.io/"
+
+Setting "other" status
+======================
+
+If none of the above states are appropriate, you can specify an "other" state and explain with a ``note``:
+
+.. code-block:: toml
+   :caption: technote.toml
+
+   [technote.status]
+   state = "other"
+   note = "Explaination of status..."

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -7,6 +7,14 @@ User guide
 .. toctree::
    :maxdepth: 2
    :titlesonly:
+   :caption: Configuration
+
+   configure-authors
+   technote-toml
+
+.. toctree::
+   :maxdepth: 2
+   :titlesonly:
+   :caption: Curation
 
    metadata
-   technote-toml

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -11,6 +11,7 @@ User guide
 
    configure-authors
    configure-status
+   configure-sphinx
    technote-toml
 
 .. toctree::

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -5,18 +5,19 @@ User guide
 ##########
 
 .. toctree::
+   :name: toc-config
    :maxdepth: 2
-   :titlesonly:
    :caption: Configuration
 
+   configuration-overview
    configure-authors
    configure-status
    configure-sphinx
    technote-toml
 
 .. toctree::
+   :name: toc-curation
    :maxdepth: 2
-   :titlesonly:
    :caption: Curation
 
    metadata

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -9,3 +9,4 @@ User guide
    :titlesonly:
 
    metadata
+   technote-toml

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -21,3 +21,10 @@ User guide
    :caption: Curation
 
    metadata
+
+.. toctree::
+   :name: toc-theming
+   :maxdepth: 2
+   :caption: Theming
+
+   theming-overview

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -10,6 +10,7 @@ User guide
    :caption: Configuration
 
    configure-authors
+   configure-status
    technote-toml
 
 .. toctree::

--- a/docs/user-guide/technote-toml.rst
+++ b/docs/user-guide/technote-toml.rst
@@ -1,0 +1,510 @@
+#######################
+technote.toml reference
+#######################
+
+The :file:`technote.toml` file contains metadata about the technote, along with configuration options for the Sphinx build.
+This page describes the schema for this file.
+
+.. seealso::
+
+   If you are not familiar with TOML, see the `TOML documentation <https://toml.io/en/v1.0.0>`_.
+
+.. _toml-technote:
+
+[technote]
+==========
+
+|required|
+
+The ``[technote]`` table is the root table for technote metadata and configuration in the :file:`technote.toml` file.
+
+.. _toml-technote-id:
+
+id
+--
+
+|optional|
+
+An internal identifier for the technote.
+
+.. code-block:: toml
+
+   [technote]
+   id = "SQR-001"
+
+.. see also::
+
+   :ref:`toml-technote-series-id`
+
+.. _toml-technote-series-id:
+
+series_id
+---------
+
+|optional|
+
+An internal identifier for a series or collection this technote belongs to.
+
+.. code-block:: toml
+
+   [technote]
+   id = "SQR-001"
+   series_id = "SQR"
+
+.. see also::
+
+   :ref:`toml-technote-id`
+
+.. _toml-technote-title:
+
+title
+-----
+
+|optional|
+
+The title of the technote.
+Use this metadata field to override the title in the content.
+Generally this metadata *should not* be set in :file:`technote.toml` if the document title in content file is correct.
+
+.. _toml-technote-date-created:
+
+date_created
+------------
+
+|optional|
+
+Date and time when the technote was created.
+This should be set as an ISO8601 string.
+Either as a date (``YYYY-MM-DD``) or a date and time with a timezone (``YYYY-MM-DDTHH:MM:SSZ``).
+
+.. _toml-technote-date-modified:
+
+date_modified
+-------------
+
+|optional|
+
+Date and time when the technote was last updated.
+This should be set as an ISO8601 string.
+Either as a date (``YYYY-MM-DD``) or a date and time with a timezone (``YYYY-MM-DDTHH:MM:SSZ``).
+
+.. _toml-technote-version:
+
+version
+-------
+
+|optional|
+
+The version of the technote.
+
+.. _toml-technote-doi:
+
+doi
+---
+
+|optional|
+
+The most-relevant DOI that identifies this technote.
+This can be a pre-registerered DOI (i.e. for Zenodo) so that the  DOI can be present in the released technote source.
+
+.. _toml-technote-canonical-url:
+
+canonical_url
+-------------
+
+|optional|
+
+The URL where this technote is published.
+
+.. _toml-technote-github-url:
+
+github_url
+----------
+
+|optional|
+
+The URL of the GitHub repository hosting this technote.
+
+.. _toml-technote-github-default-branch:
+
+github_default_branch
+---------------------
+
+|optional| Default: ``main``
+
+The default branch of the GitHub repository.
+
+.. _toml-technote-authors:
+
+[[technote.authors]]
+====================
+
+Authors are specified as an array of tables.
+In :file:`technote.toml`, this means that each author is described with their own ``[[technote.authors]]`` table.
+You can have as many ``[[technote.authors]]`` tables as you need.
+
+.. _toml-technote-authors-name:
+
+name
+----
+
+|required|
+
+The author's name, as it should appear in the technote.
+The name can be specified either of two ways.
+First, as a single string:
+
+.. code-block:: toml
+
+   [[technote.authors]]
+   name = { "name": "Vera Rubin" }
+
+Alternatively, as structured family and given names:
+
+.. code-block:: toml
+
+   [[technote.authors]]
+   name = { "given_names": "Vera", "family_names": "Rubin" }
+
+The choice of syntax depends on the requirements of your organization and its metadata and theming tools for technotes.
+
+.. _toml-technote-authors-internal-id:
+
+internal_id
+-----------
+
+|optional|
+
+An internal identifier for the person.
+This can be used to associate an author with an organization's author database.
+
+.. _toml-technote-authors-email:
+
+email
+-----
+
+|optional|
+
+The author's email address.
+
+.. _toml-technote-authors-orcid:
+
+orcid
+-----
+
+|optional|
+
+The author's ORCiD identifier.
+This should be specified as a full URL.
+
+.. _toml-technote-authors-affiliations:
+
+[[technote.authors.affiliations]]
+=================================
+
+|optional|
+
+An author can have multiple affiliations.
+Each affiliation is a table in the ``[[technote.authors.affiliations]]`` array.
+
+.. code-block:: toml
+
+   [technote.authors]
+   name = { "name": "Vera Rubin" }
+   affiliations = [
+     { name = "Department of Astronomy, University of Washington" },
+     { name = "Department of Terrestrial Magnetism, Carnegie Institution of Washington" }
+   ]
+
+The above example used inline tables for each affiliation.
+If each affiliation has a large amount of metadata you can instead use the array of table TOML syntax:
+
+.. code-block:: toml
+
+   [technote.authors]
+   name = { "name": "Vera Rubin" }
+   [[technote.authors.affiliations]]
+   name = "Department of Astronomy, University of Washington"
+   [[technote.authors.affiliations]]
+   name = "Department of Terrestrial Magnetism, Carnegie Institution of Washington"
+
+.. _toml-technote-authors-affiliations-name:
+
+name
+----
+
+|optional|
+
+The name of the entity.
+
+.. _toml-technote-authors-affiliations-internal-id:
+
+internal_id
+-----------
+
+|optional|
+
+An internal identifier for the entity.
+This field can be used to an organization's database of affiliations.
+
+.. _toml-technote-authors-affiliations-address:
+
+address
+-------
+
+|optional|
+
+The address of the entity.
+
+.. _toml-technote-authors-affiliations-url:
+
+url
+---
+
+|optional|
+
+The homepage of the entity.
+
+.. _toml-technote-authors-affiliations-ror:
+
+ror
+---
+
+|optional|
+
+The `ROR <https://ror.org>`__ identifier of the entity.
+This should be specified as a full URL.
+ROR is a *research organization registry* that provides a persistent identifier for research organizations, similar to ORCiD identifiers for individual researchers.
+
+.. _toml-technote-contributors:
+
+[[technote.contributors]]
+=========================
+
+|optional|
+
+Besides authors, a technote can have other contributors such as reviewers, editors, and approvers.
+The ``[[technote.contributors]]`` array of tables is structured identically to the ``[[technote.authors]]`` array of tables, with the addition of ``role`` and ``note`` keys.
+
+.. _toml-technote-contributors-role:
+
+role
+----
+
+|optional|
+
+The role of the contributor.
+This is an enumeration of one of the following values from the Zenodo schema:
+
+- ``ContactPerson``
+- ``DataCollector``
+- ``DataCurator``
+- ``DataManager``
+- ``Distributor``
+- ``Editor``
+- ``Funder``
+- ``HostingInstitution``
+- ``Producer``
+- ``ProjectLeader``
+- ``ProjectManager``
+- ``ProjectMember``
+- ``RegistrationAgency``
+- ``RegistrationAuthority``
+- ``RelatedPerson``
+- ``Researcher``
+- ``ResearchGroup``
+- ``RightsHolder``
+- ``Supervisor``
+- ``Sponsor``
+- ``WorkPackageLeader``
+- ``Other``
+
+.. _toml-technote-contributors-note:
+
+note
+----
+
+|optional|
+
+A note describing the role of the contributor.
+This is particularly useful if the role is "Other".
+
+.. _toml-technote-status:
+
+[technote.status]
+=================
+
+|optional|
+
+A technote is an evolving document.
+You can describe whether the technote is being actively drafted, stable, or deprecated with the ``[technote.status]`` table.
+
+.. _toml-technote-status-state:
+
+state
+-----
+
+|required|
+
+The state of the technote is an enumeration with the following allowed values:
+
+``draft``
+    The technote is being actively drafted or is not in a complete state.
+
+``stable``
+    The technote is stable and complete.
+
+``deprecated``
+    The technote is deprecated and should not be used.
+
+``other``
+    The technote is in some other state. Use the ``note`` key to describe the state.
+
+.. _toml-technote-status-note:
+
+note
+----
+
+|optional|
+
+A note describing the state of the technote.
+
+.. _toml-technote-status-superseding-urls:
+
+[[technote.status.superseding_urls]]
+====================================
+
+|optional|
+
+A deprecated technote might be supersceded by other works.
+Use this array of tables to describe those links
+
+.. _toml-technote-status-superseding-urls-url:
+
+url
+---
+
+|required|
+
+The URL of the work that supersedes this technote.
+
+.. _toml-technote-status-superseding-urls-title:
+
+title
+-----
+
+|optional|
+
+The title of the work that supersedes this technote.
+
+.. _toml-technote-license:
+
+[technote.license]
+==================
+
+|optional|
+
+The license of the technote.
+
+.. code-block:: toml
+
+   [technote.license]
+   id = "CC-BY-4.0"
+
+.. _toml-technote-license-id:
+
+id
+--
+
+|required|
+
+The `SPDX identifier <https://spdx.org/licenses/>`__ of the license.
+
+.. _toml-technote-sphinx:
+
+[technote.sphinx]
+=================
+
+|optional|
+
+You can specify many configurations for the Sphinx build in the ``[technote.sphinx]`` table.
+Technote's Sphinx configuration module, ``technote.sphinxconf``, applies these values in the Sphinx :file:`conf.py` file.
+
+.. _toml-technote-sphinx-extensions:
+
+extensions
+----------
+
+|optional|
+
+An array of Sphinx extensions to enable, equivalent to the ``extensions`` list in Sphinx's :file:`conf.py`.
+
+.. _toml-technote-sphinx-nitpicky:
+
+nitpicky
+--------
+
+|optional| Default: ``false``
+
+Escalates build warnings to errors.
+
+.. _toml-technote-sphinx-nitpick-ignore:
+
+nitpick_ignore
+--------------
+
+|optional|
+
+An array of two-item arrays specifying errors to ignore.
+The first item is the type (such as a role like ``py:class``), and the second item is the target (such as a class name).
+
+.. _toml-technote-sphinx-nitpick-ignore-regex:
+
+nitpick_ignore_regex
+--------------------
+
+|optional|
+
+Same as ``nitpick_ignore``, but items are interpreted as regular expressions.
+
+.. _toml-technote-sphinx-intersphinx:
+
+[technote.sphinx.intersphinx]
+=============================
+
+|optional|
+
+Configurations for the ``intersphinx`` Sphinx extension.
+
+.. _toml-technote-sphinx-intersphinx-projects:
+
+[technote.sphinx.intersphinx.projects]
+======================================
+
+|optional|
+
+A table of Sphinx project names and their root documentation URLs.
+
+.. code-block:: toml
+
+   [technote.sphinx.intersphinx.projects]
+   python = "https://docs.python.org/3/"
+   sphinx = "https://www.sphinx-doc.org/en/master/"
+
+.. _toml-technote-sphinx-linkcheck:
+
+[technote.sphinx.linkcheck]
+===========================
+
+|optional|
+
+Configurations for the ``linkcheck`` Sphinx extension.
+
+.. _toml-technote-sphinx-linkcheck-ignore:
+
+ignore
+------
+
+|optional|
+
+An array of regular expressions for URLs to ignore when checking links.

--- a/docs/user-guide/theming-overview.rst
+++ b/docs/user-guide/theming-overview.rst
@@ -1,0 +1,35 @@
+####################################
+Theming an organizations's technotes
+####################################
+
+Technotes are intended to be branded and customized by each organization that creates and publishes theme.
+The general steps for creating a technote theme are:
+
+1. Create a Python package that individual technote projects can import (such as from PyPI, conda-forge, or even GitHub). This package needs to include ``technote`` as a dependency. For example, Rubin Observatory uses Documenteer_ (https://github.com/lsst-sqre/documenteer) as its theme package.
+
+2. Create a configuration module that imports the base technote configuration and then appends any additional Sphinx configurations.
+
+   .. code-block:: python
+
+      from technote.sphinxconf import *
+
+      # Add additional configurations below
+
+   For an example, see `Documenteer's configuration module <https://documenteer.lsst.io/technotes/configuration.html#configuration-source-reference>`__.
+
+3. Add custom CSS. Declare the CSS file in your package to the ``html_static_path`` variable in the Sphinx configuration module, and then append the name of that CSS file to the ``html_css_files`` list in the Sphinx configuration module.
+
+4. Add Jinja custom templates that override the built-in ones from technote (`see the templates on GitHub <https://github.com/lsst-sqre/technote/tree/main/src/technote/theme>`__). Declare the directory in your package containing these templates to the ``templates_path`` variable in the Sphinx configuration module.
+
+5. Set the logos and the logos' links by setting ``html_theme_options``. For example:
+
+   .. code-block:: python
+
+      html_theme_options = {
+          "light_logo": "rubin-imagotype-color-on-white-crop.svg",
+          "dark_logo": "rubin-imagotype-color-on-black-crop.svg",
+          "logo_link_url": "https://www.lsst.io",
+          "logo_alt_text": "Rubin Observatory logo",
+      }
+
+   Don't forget to declare the path locations of image assets in your package to the ``html_static_path`` variable in the Sphinx configuration module.


### PR DESCRIPTION
New documentation:

- Reference page for `technote.toml` settings
- Page on adding authors to `technote.toml`
- Page on setting the document status (ported from Documenteer)
- Overview of the configuration system
- Overview of creating themes for technotes