### PR TITLE
DM-41707: Dynamically detect root source file

### DIFF
--- a/changelog.d/20231114_132232_jsick_DM_41707.md
+++ b/changelog.d/20231114_132232_jsick_DM_41707.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- The edit-on-GitHub link created in the Jinja context now correctly points to `index.md` if appropriate. Previously it assumed that the source page would be `index.rst`.

--- a/src/technote/factory.py
+++ b/src/technote/factory.py
@@ -123,10 +123,12 @@ class Factory:
         )
 
     def create_jinja_context(
-        self, metadata: TechnoteMetadata
+        self, metadata: TechnoteMetadata, root_filename: Path
     ) -> TechnoteJinjaContext:
         """Create the Jinja context for the technote."""
         # We don't use a cached TechnoteMetadata because TechnoteSphinxConfig
         # or TechnoteJinjaContext may modify the metadata. We don't want to
         # own it in the factory.
-        return TechnoteJinjaContext(metadata=metadata)
+        return TechnoteJinjaContext(
+            metadata=metadata, root_filename=root_filename
+        )

--- a/src/technote/templating/context.py
+++ b/src/technote/templating/context.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from datetime import UTC, datetime
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 from urllib.parse import urlparse
 
 from ..metadata.model import TechnoteMetadata
@@ -22,8 +23,11 @@ class TechnoteJinjaContext:
         The technote metadata.
     """
 
-    def __init__(self, metadata: TechnoteMetadata) -> None:
+    def __init__(
+        self, metadata: TechnoteMetadata, root_filename: Path
+    ) -> None:
         self._metadata = metadata
+        self._root_filename = root_filename
 
     @property
     def metadata(self) -> TechnoteMetadata:
@@ -143,12 +147,13 @@ class TechnoteJinjaContext:
         else:
             root_url = self.github_url
 
-        # FIXME: compute source path during Sphinx build
+        filename = self._root_filename.name
+
         # We're using /blob/ instead of /edit/ to give users the choice of
         # how to edit (on web or in github.dev).
         return (
             f"{root_url}/blob/"
-            f"{self.metadata.source_repository.branch or 'main'}/index.rst"
+            f"{self.metadata.source_repository.branch or 'main'}/{filename}"
         )
 
     def set_content_title(self, title: str) -> None:

--- a/tests/templating/context_test.py
+++ b/tests/templating/context_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from _pytest.monkeypatch import MonkeyPatch
 
 from technote.factory import Factory
@@ -35,7 +37,9 @@ def test_technote_jinja_context(monkeypatch: MonkeyPatch) -> None:
     technote_toml = factory.parse_toml(sample_toml)
     factory._toml = technote_toml
     metadata = factory.load_metadata()
-    jinja_context = factory.create_jinja_context(metadata=metadata)
+    jinja_context = factory.create_jinja_context(
+        metadata=metadata, root_filename=Path("index.rst")
+    )
 
     assert jinja_context.github_url == "https://github.com/lsst-sqre/sqr-000"
     assert jinja_context.github_repo_slug == "lsst-sqre/sqr-000"


### PR DESCRIPTION
Previously we assumed the source file was "index.rst" for the purpose of building the edit-on-github link. Now, in the factory TechnoteSphinxConfig we check if index.rst, index.md, or index.ipynb exist, and then set that path as appropriate. This propagates to TechnoteJinjaContext where the edit on github link is built.