### PR TITLE
DM-41905: Add sphinx.ext.intersphinx to the extensions list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.5.1'></a>
+## 0.5.1 (2023-11-29)
+
+### Bug fixes
+
+- Add `sphinx.ext.intersphinx` to the `extensions` list in `technote.sphinxconf`. This extension is required to use the `[technote.sphinx.intersphinx]` configuration.
+
 <a id='changelog-0.5.0'></a>
 ## 0.5.0 (2023-11-28)
 

--- a/changelog.d/20231129_133220_jsick_DM_41905.md
+++ b/changelog.d/20231129_133220_jsick_DM_41905.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Add `sphinx.ext.intersphinx` to the `extensions` list in `technote.sphinxconf`. This extension is required to use the `[technote.sphinx.intersphinx]` configuration.

--- a/changelog.d/20231129_133220_jsick_DM_41905.md
+++ b/changelog.d/20231129_133220_jsick_DM_41905.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-- Add `sphinx.ext.intersphinx` to the `extensions` list in `technote.sphinxconf`. This extension is required to use the `[technote.sphinx.intersphinx]` configuration.

--- a/src/technote/sphinxconf.py
+++ b/src/technote/sphinxconf.py
@@ -69,6 +69,7 @@ html_theme = "technote"
 
 extensions: list[str] = [
     "myst_parser",
+    "sphinx.ext.intersphinx",
     "technote.ext",
 ]
 _t.append_extensions(extensions)


### PR DESCRIPTION
This extension is required to make the `[technote.sphinx.intersphinx]` configuration work.