### PR TITLE
DM-41917: Export TechnoteSphinxConfig instance from config

### DIFF
--- a/changelog.d/20231130_191631_jsick_DM_41917.md
+++ b/changelog.d/20231130_191631_jsick_DM_41917.md
@@ -1,0 +1,17 @@
+<!-- Delete the sections that don't apply -->
+
+### Backwards-incompatible changes
+
+-
+
+### New features
+
+- Export a variable, `T` from `technote.sphinxconf` that is an instance of `technote.main.TechnoteSphinxConfig`. This is useful for organizations that need to access the technote configuration and metadata in their own technote theme.
+
+### Bug fixes
+
+-
+
+### Other changes
+
+-

--- a/docs/user-guide/theming-overview.rst
+++ b/docs/user-guide/theming-overview.rst
@@ -17,6 +17,8 @@ The general steps for creating a technote theme are:
 
    For an example, see `Documenteer's configuration module <https://documenteer.lsst.io/technotes/configuration.html#configuration-source-reference>`__.
 
+   To access metadata and configuration from :file:`technote.toml`, use the ``T`` variable exported from ``technote.sphinxconf``, which is an instance of `~technote.main.TechnoteSphinxConfig`.
+
 3. Add custom CSS. Declare the CSS file in your package to the ``html_static_path`` variable in the Sphinx configuration module, and then append the name of that CSS file to the ``html_css_files`` list in the Sphinx configuration module.
 
 4. Add Jinja custom templates that override the built-in ones from technote (`see the templates on GitHub <https://github.com/lsst-sqre/technote/tree/main/src/technote/theme>`__). Declare the directory in your package containing these templates to the ``templates_path`` variable in the Sphinx configuration module.

--- a/src/technote/sphinxconf.py
+++ b/src/technote/sphinxconf.py
@@ -13,6 +13,8 @@ from .main import TechnoteSphinxConfig
 
 # Restrict to only Sphinx configurations
 __all__ = [
+    # Technote configuration
+    "T",
     # SPHINX
     "project",
     "author",
@@ -41,14 +43,14 @@ __all__ = [
     "myst_enable_extensions",
 ]
 
-_t = TechnoteSphinxConfig.load()
+T = TechnoteSphinxConfig.load()
 
 # ============================================================================
 # SPHINX General sphinx settings
 # ============================================================================
 
-project = _t.title or ""
-author = _t.author or ""
+project = T.title or ""
+author = T.author or ""
 exclude_patterns = [
     "_build",
     ".technote",
@@ -72,7 +74,7 @@ extensions: list[str] = [
     "sphinx.ext.intersphinx",
     "technote.ext",
 ]
-_t.append_extensions(extensions)
+T.append_extensions(extensions)
 
 # Add support for both Markdown and reStructuredText sources
 source_suffix = {
@@ -81,20 +83,20 @@ source_suffix = {
 }
 
 # Nitpicky settings and ignored errors
-nitpicky = _t.nitpicky
+nitpicky = T.nitpicky
 
 nitpick_ignore: list[tuple[str, str]] = []
-_t.append_nitpick_ignore(nitpick_ignore)
+T.append_nitpick_ignore(nitpick_ignore)
 
 nitpick_ignore_regex: list[tuple[str, str]] = []
-_t.append_nitpick_ignore_regex(nitpick_ignore_regex)
+T.append_nitpick_ignore_regex(nitpick_ignore_regex)
 
 # ============================================================================
 # INTERSPHINX Intersphinx settings
 # ============================================================================
 
 intersphinx_mapping: dict[str, tuple[str, str | None]] = {}
-_t.extend_intersphinx_mapping(intersphinx_mapping)
+T.extend_intersphinx_mapping(intersphinx_mapping)
 
 intersphinx_timeout = 10.0  # seconds
 
@@ -108,16 +110,16 @@ intersphinx_cache_limit = 5  # days
 linkcheck_retries = 2
 linkcheck_timeout = 15
 linkcheck_ignore: list[str] = []
-_t.append_linkcheck_ignore(linkcheck_ignore)
+T.append_linkcheck_ignore(linkcheck_ignore)
 
 # ============================================================================
 # HTML HTML builder settings
 # ============================================================================
 
-html_context: dict[str, Any] = {"technote": _t.jinja_context}
+html_context: dict[str, Any] = {"technote": T.jinja_context}
 
-if _t.toml.technote.canonical_url:
-    html_baseurl = str(_t.toml.technote.canonical_url)
+if T.toml.technote.canonical_url:
+    html_baseurl = str(T.toml.technote.canonical_url)
 else:
     html_baseurl = ""
 


### PR DESCRIPTION
Export a variable, `T` from `technote.sphinxconf` that is an instance of `technote.main.TechnoteSphinxConfig`. This is useful for organizations that need to access the technote configuration and metadata in their own technote theme.