### PR TITLE
DM-42124: Handle non-html builders for extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.6.1'></a>
+## 0.6.1 (2023-12-14)
+
+### Bug fixes
+
+- The `technote.ext.wraptables` and `technote.ext.insertposttitles` extensions now gracefully handle cases when an `index.html` file does not exist. A reason for this might be that the build is running through the linkcheck builder.
+
 <a id='changelog-0.6.0'></a>
 ## 0.6.0 (2023-12-05)
 

--- a/changelog.d/20231214_162329_jsick_DM_42142.md
+++ b/changelog.d/20231214_162329_jsick_DM_42142.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- The `technote.ext.wraptables` and `technote.ext.insertposttitles` extensions now gracefully handle cases when an `index.html` file does not exist. A reason for this might be that the build is running through the linkcheck builder.

--- a/changelog.d/20231214_162329_jsick_DM_42142.md
+++ b/changelog.d/20231214_162329_jsick_DM_42142.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-- The `technote.ext.wraptables` and `technote.ext.insertposttitles` extensions now gracefully handle cases when an `index.html` file does not exist. A reason for this might be that the build is running through the linkcheck builder.

--- a/src/technote/ext/insertposttitle.py
+++ b/src/technote/ext/insertposttitle.py
@@ -43,6 +43,8 @@ def insert_post_title(app: Sphinx, exceptions: Exception | None) -> None:
 
     # Insert the status aside into the technote
     html_path = Path(app.builder.outdir) / "index.html"
+    if not html_path.is_file():
+        return
     soup = BeautifulSoup(html_path.read_text(), "html.parser")
     title = soup.find("h1")
     title.insert_after(status_soup)

--- a/src/technote/ext/wraptables.py
+++ b/src/technote/ext/wraptables.py
@@ -25,6 +25,8 @@ def wrap_html_tables(app: Sphinx, exceptions: Exception | None = None) -> None:
     # Assumes that technotes consist of only a single index.html file
     # by definition.
     html_path = Path(app.builder.outdir) / "index.html"
+    if not html_path.is_file():
+        return
 
     soup = BeautifulSoup(html_path.read_text(), "html.parser")
     for table_element in soup.find_all("table"):


### PR DESCRIPTION
The wraptables and insertposttitles extensions will fail if an index.html doesn't exist. This will be the case for the linkcheck builder for instance. Now these extensions silently exit when index.html don't exist.