### PR TITLE
DM-42142: Update pygments extension to work with linkcheck builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.6.2'></a>
+## 0.6.2 (2023-12-14)
+
+### Bug fixes
+
+- Fix the `technote.ext.pygmentsscss` extension to handle cases where the HTML builder isn't being run.
+
 <a id='changelog-0.6.1'></a>
 ## 0.6.1 (2023-12-14)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10385500.svg)](https://doi.org/10.5281/zenodo.10385500)
+[![Python CI](https://github.com/lsst-sqre/technote/actions/workflows/ci.yaml/badge.svg)](https://github.com/lsst-sqre/technote/actions/workflows/ci.yaml)
+
 # Technote
 
 Rubin Observatory's framework for Sphinx-based technote documents.

--- a/changelog.d/20231214_180523_jsick_DM_42142.md
+++ b/changelog.d/20231214_180523_jsick_DM_42142.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-- Fix the `technote.ext.pygmentsscss` extension to handle cases where the HTML builder isn't being run.

--- a/changelog.d/20231214_180523_jsick_DM_42142.md
+++ b/changelog.d/20231214_180523_jsick_DM_42142.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fix the `technote.ext.pygmentsscss` extension to handle cases where the HTML builder isn't being run.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,14 @@ technote is developed on GitHub at https://github.com/lsst-sqre/technote.
 
    View a demo technote page
 
+Cite Technote
+=============
+
+You can cite the latest Technote release if you mention Technote in a publication:
+
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.10385500.svg
+  :target: https://doi.org/10.5281/zenodo.10385500
+
 .. toctree::
    :hidden:
 

--- a/src/technote/ext/pygmentscss.py
+++ b/src/technote/ext/pygmentscss.py
@@ -29,6 +29,9 @@ def overwrite_pygments_css(
         return
 
     pygment_css_path = Path(app.builder.outdir) / "_static" / "pygments.css"
+    if not pygment_css_path.is_file():
+        # Handles cases where the html builder isn't running (e.g. link check)
+        return
     pygments_css = _create_pygments_css()
     pygment_css_path.write_text(pygments_css)
 


### PR DESCRIPTION
Fix the `technote.ext.pygmentsscss` extension to handle cases where the HTML builder isn't being run, and therefore the _static/ directory isn't available.