### PR TITLE
DM-42711: Improve code samples without captions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.7.0'></a>
+## 0.7.0 (2024-01-30)
+
+### New features
+
+- When the `technote.date_updated` field in `technote.toml` is not set, the update date internally defaults to "now" (the build time). This ensures that documents always carry some form of metadata about when they were modified.
+
+- Code samples without captions (unwrapped `.highlight` divs) now have borders and are protected against x-overflow. This matches the behavior of code samples with captions.
+- All code samples have negative left margin equal to their content padding so that the code lines up with the text column.
+- The content (`div.sb-container`) now has bottom margin to give content breathing room.
+
 <a id='changelog-0.6.2'></a>
 ## 0.6.2 (2023-12-14)
 

--- a/changelog.d/20240129_154947_jsick_DM_42705.md
+++ b/changelog.d/20240129_154947_jsick_DM_42705.md
@@ -1,3 +1,0 @@
-### New features
-
-- When the `technote.date_updated` field in `technote.toml` is not set, the update date internally defaults to "now" (the build time). This ensures that documents always carry some form of metadata about when they were modified.

--- a/changelog.d/20240130_170658_jsick_DM_42711.md
+++ b/changelog.d/20240130_170658_jsick_DM_42711.md
@@ -1,0 +1,5 @@
+### New features
+
+- Code samples without captions (unwrapped `.highlight` divs) now have borders and are protected against x-overflow. This matches the behavior of code samples with captions.
+- All code samples have negative left margin equal to their content padding so that the code lines up with the text column.
+- The content (`div.sb-container`) now has bottom margin to give content breathing room.

--- a/changelog.d/20240130_170658_jsick_DM_42711.md
+++ b/changelog.d/20240130_170658_jsick_DM_42711.md
@@ -1,5 +1,0 @@
-### New features
-
-- Code samples without captions (unwrapped `.highlight` divs) now have borders and are protected against x-overflow. This matches the behavior of code samples with captions.
-- All code samples have negative left margin equal to their content padding so that the code lines up with the text column.
-- The content (`div.sb-container`) now has bottom margin to give content breathing room.

--- a/demo/rst/index.rst
+++ b/demo/rst/index.rst
@@ -94,6 +94,28 @@ This is a long code cell:
    run:
    	cd server && tox run -e=run
 
+A code cell without a caption:
+
+.. code-block:: python
+
+   print("Hello world")
+
+A code sample with no language set::
+
+   Hello world
+
+A wide code sample with no caption:
+
+.. code-block:: Makefile
+
+   .PHONY: update-deps
+   update-deps:
+   	pip install --upgrade pip-tools pip setuptools
+   	pip-compile --upgrade --build-isolation --generate-hashes --output-file server/requirements/main.hashed.txt server/requirements/main.in
+   	pip-compile --upgrade --build-isolation --generate-hashes --output-file server/requirements/dev.hashed.txt server/requirements/dev.in
+   	pip-compile --upgrade --build-isolation --allow-unsafe --output-file server/requirements/main.txt server/requirements/main.in
+   	pip-compile --upgrade --build-isolation --allow-unsafe --output-file server/requirements/dev.txt server/requirements/dev.in
+
 Admonitions
 ===========
 

--- a/src/assets/styles/base/_layout.scss
+++ b/src/assets/styles/base/_layout.scss
@@ -6,6 +6,7 @@
 
 .sb-container {
   margin-top: var(--tn-space-md-fixed);
+  margin-bottom: var(--tn-space-xxl-fixed);
 }
 
 /* Style the prmary sidebar when it's a popover. */

--- a/src/assets/styles/base/_sphinx.scss
+++ b/src/assets/styles/base/_sphinx.scss
@@ -29,13 +29,16 @@ pre {
   font-size: 0.85rem;
 }
 
-.literal-block-wrapper .highlight pre {
+.highlight pre {
   margin: 0;
+  margin-left: calc(-1 * var(--tn-space-xs-fixed));
   padding: var(--tn-space-xs-fixed);
   overflow-x: auto;
 }
 
 .literal-block-wrapper {
+  margin-left: calc(-1 * var(--tn-space-xs-fixed));
+  padding-left: var(--tn-space-xs-fixed);
   border: var(--tn-sphinx-code-block-border-thickness) solid
     var(--tn-sphinx-code-block-border-color);
   border-radius: var(--tn-sphinx-code-block-border-radius);
@@ -55,6 +58,7 @@ pre {
   border-radius: var(--tn-sphinx-code-block-border-radius)
     var(--tn-sphinx-code-block-border-radius) 0 0;
   padding: var(--tn-space-xxxs-fixed) var(--tn-space-xs-fixed);
+  margin-left: calc(-1 * var(--tn-space-xs-fixed));
 }
 
 .admonition {

--- a/src/assets/styles/base/_sphinx.scss
+++ b/src/assets/styles/base/_sphinx.scss
@@ -29,11 +29,14 @@ pre {
   font-size: 0.85rem;
 }
 
-.highlight pre {
+.highlight {
   margin: 0;
   margin-left: calc(-1 * var(--tn-space-xs-fixed));
   padding: var(--tn-space-xs-fixed);
   overflow-x: auto;
+  border: var(--tn-sphinx-code-block-border-thickness) solid
+    var(--tn-sphinx-code-block-border-color);
+  border-radius: var(--tn-sphinx-code-block-border-radius);
 }
 
 .literal-block-wrapper {
@@ -45,10 +48,9 @@ pre {
 }
 
 .literal-block-wrapper .highlight {
-  // This border radius ensures the pygments background on .highlight doesn't
-  // interfere with the border radius of the .literal-block-wrapper.
-  border-radius: 0 0 var(--tn-sphinx-code-block-border-radius)
-    var(--tn-sphinx-code-block-border-radius);
+  // If the code sample has a caption, then turn off its border so that the
+  // border comes from the overall wrapper (.literal-block-wrapper).
+  border: none;
 }
 
 .code-block-caption {


### PR DESCRIPTION
- Code samples without captions (unwrapped `.highlight` divs) now have borders and are protected against x-overflow. This matches the behavior of code samples with captions.
- All code samples have negative left margin equal to their content padding so that the code lines up with the text column.
- The content (`div.sb-container`) now has bottom margin to give content breathing room.
