### PR TITLE
DM-42626: Fix configuration documentation for intersphinx

### DIFF
--- a/docs/user-guide/configure-sphinx.rst
+++ b/docs/user-guide/configure-sphinx.rst
@@ -38,7 +38,7 @@ To add a site to the Intersphinx_ configuration, add items to the ``[technote.sp
 .. code-block:: toml
    :caption: technote.toml
 
-   [technote.sphinx.intersphinx]
+   [technote.sphinx.intersphinx.projects]
    astropy = "https://docs.astropy.org/en/stable/"
    python = "https://docs.python.org/3/"
 


### PR DESCRIPTION
The setting honored in code is technote.sphinx.intersphinx.projects. Change the documentation to match.